### PR TITLE
WIP: experimental performance decrease

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
   [[pretty "1.0.0"]
    [potemkin "0.4.5"]]
 
-  :aot [methodical.interface methodical.impl.standard]
+  :aot [methodical.impl.standard]
 
   :jvm-opts ["-Dclojure.compiler.direct-linking=true"]
 

--- a/src/methodical/after.txt
+++ b/src/methodical/after.txt
@@ -1,0 +1,86 @@
+(profile)
+
+
+Profiling plain fns...
+Evaluation count : 921179100 in 60 samples of 15352985 calls.
+             Execution time mean : 58,672614 ns
+    Execution time std-deviation : 3,121113 ns
+   Execution time lower quantile : 56,465928 ns ( 2,5%)
+   Execution time upper quantile : 67,537719 ns (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 8 outliers in 60 samples (13,3333 %)
+        low-severe	 3 (5,0000 %)
+        low-mild	 5 (8,3333 %)
+ Variance from outliers : 38,5275 % Variance is moderately inflated by outliers
+
+
+Profiling methodical...
+Evaluation count : 12310320 in 60 samples of 205172 calls.
+             Execution time mean : 4,945147 µs
+    Execution time std-deviation : 111,030217 ns
+   Execution time lower quantile : 4,797622 µs ( 2,5%)
+   Execution time upper quantile : 5,195639 µs (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 2 outliers in 60 samples (3,3333 %)
+        low-severe	 2 (3,3333 %)
+ Variance from outliers : 10,9635 % Variance is moderately inflated by outliers
+
+
+Profiling vanilla clojure multimethod...
+Evaluation count : 619336320 in 60 samples of 10322272 calls.
+             Execution time mean : 87,838083 ns
+    Execution time std-deviation : 2,354604 ns
+   Execution time lower quantile : 83,970415 ns ( 2,5%)
+   Execution time upper quantile : 91,613467 ns (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 3 outliers in 60 samples (5,0000 %)
+        low-severe	 1 (1,6667 %)
+        low-mild	 1 (1,6667 %)
+        high-mild	 1 (1,6667 %)
+ Variance from outliers : 14,1846 % Variance is moderately inflated by outliers
+(profile-big-hierarchy)
+
+
+vanilla clojure
+Evaluation count : 2309105340 in 60 samples of 38485089 calls.
+             Execution time mean : 17,462694 ns
+    Execution time std-deviation : 0,637189 ns
+   Execution time lower quantile : 16,740270 ns ( 2,5%)
+   Execution time upper quantile : 19,011378 ns (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 4 outliers in 60 samples (6,6667 %)
+        low-severe	 3 (5,0000 %)
+        low-mild	 1 (1,6667 %)
+ Variance from outliers : 23,7775 % Variance is moderately inflated by outliers
+
+
+methodical
+Evaluation count : 26667780 in 60 samples of 444463 calls.
+             Execution time mean : 2,401364 µs
+    Execution time std-deviation : 91,221632 ns
+   Execution time lower quantile : 2,301876 µs ( 2,5%)
+   Execution time upper quantile : 2,609200 µs (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 4 outliers in 60 samples (6,6667 %)
+        low-severe	 2 (3,3333 %)
+        low-mild	 2 (3,3333 %)
+ Variance from outliers : 23,8721 % Variance is moderately inflated by outliers
+
+
+methodical clojure
+Evaluation count : 42115320 in 60 samples of 701922 calls.
+             Execution time mean : 1,476671 µs
+    Execution time std-deviation : 75,846076 ns
+   Execution time lower quantile : 1,399422 µs ( 2,5%)
+   Execution time upper quantile : 1,625068 µs (97,5%)
+                   Overhead used : 8,821677 ns
+
+Found 3 outliers in 60 samples (5,0000 %)
+        low-severe	 2 (3,3333 %)
+        low-mild	 1 (1,6667 %)
+ Variance from outliers : 36,8828 % Variance is moderately inflated by outliers

--- a/src/methodical/before.txt
+++ b/src/methodical/before.txt
@@ -1,0 +1,85 @@
+(profile)
+
+
+Profiling plain fns...
+Evaluation count : 878857740 in 60 samples of 14647629 calls.
+             Execution time mean : 58,356881 ns
+    Execution time std-deviation : 1,467932 ns
+   Execution time lower quantile : 55,975828 ns ( 2,5%)
+   Execution time upper quantile : 61,572447 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 2 outliers in 60 samples (3,3333 %)
+        low-severe	 2 (3,3333 %)
+ Variance from outliers : 12,6017 % Variance is moderately inflated by outliers
+
+
+Profiling methodical...
+Evaluation count : 245309700 in 60 samples of 4088495 calls.
+             Execution time mean : 238,312268 ns
+    Execution time std-deviation : 3,863088 ns
+   Execution time lower quantile : 235,595227 ns ( 2,5%)
+   Execution time upper quantile : 248,729953 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 5 outliers in 60 samples (8,3333 %)
+        low-severe	 1 (1,6667 %)
+        low-mild	 4 (6,6667 %)
+ Variance from outliers : 2,5050 % Variance is slightly inflated by outliers
+
+
+Profiling vanilla clojure multimethod...
+Evaluation count : 602111160 in 60 samples of 10035186 calls.
+             Execution time mean : 90,658622 ns
+    Execution time std-deviation : 2,566177 ns
+   Execution time lower quantile : 87,064925 ns ( 2,5%)
+   Execution time upper quantile : 96,554058 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 2 outliers in 60 samples (3,3333 %)
+        low-severe	 2 (3,3333 %)
+ Variance from outliers : 15,7638 % Variance is moderately inflated by outliers
+(profile-big-hierarchy)
+
+
+vanilla clojure
+Evaluation count : 2383367340 in 60 samples of 39722789 calls.
+             Execution time mean : 16,573010 ns
+    Execution time std-deviation : 0,538468 ns
+   Execution time lower quantile : 15,908922 ns ( 2,5%)
+   Execution time upper quantile : 17,747274 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 6 outliers in 60 samples (10,0000 %)
+        low-severe	 5 (8,3333 %)
+        low-mild	 1 (1,6667 %)
+ Variance from outliers : 19,0132 % Variance is moderately inflated by outliers
+
+
+methodical
+Evaluation count : 2329341240 in 60 samples of 38822354 calls.
+             Execution time mean : 19,027996 ns
+    Execution time std-deviation : 1,776724 ns
+   Execution time lower quantile : 17,080585 ns ( 2,5%)
+   Execution time upper quantile : 23,050789 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 4 outliers in 60 samples (6,6667 %)
+        low-severe	 2 (3,3333 %)
+        low-mild	 2 (3,3333 %)
+ Variance from outliers : 66,9386 % Variance is severely inflated by outliers
+
+
+methodical clojure
+Evaluation count : 2343900000 in 60 samples of 39065000 calls.
+             Execution time mean : 16,850978 ns
+    Execution time std-deviation : 0,312906 ns
+   Execution time lower quantile : 16,446130 ns ( 2,5%)
+   Execution time upper quantile : 17,513656 ns (97,5%)
+                   Overhead used : 8,857041 ns
+
+Found 9 outliers in 60 samples (15,0000 %)
+        low-severe	 3 (5,0000 %)
+        low-mild	 3 (5,0000 %)
+        high-mild	 3 (5,0000 %)
+ Variance from outliers : 7,8089 % Variance is slightly inflated by outliers

--- a/src/methodical/impl.clj
+++ b/src/methodical/impl.clj
@@ -17,16 +17,15 @@
             [methodical.impl.multifn
              [cached :as multifn.cached]
              [standard :as multifn.standard]]
-            [methodical.impl.standard :as impl.standard])
-  (:import methodical.impl.standard.StandardMultiFn
-           [methodical.interface Cache Dispatcher MethodCombination MethodTable MultiFnImpl]))
+            [methodical.impl.standard :as impl.standard]
+            [methodical.interface :as i]))
 
 ;;;; ### Method Combinations
 
 (defn clojure-method-combination
   "Simple method combination strategy that mimics the way vanilla Clojure multimethods combine methods; that is, to say,
   not at all. Like vanilla Clojure multimethods, this method combination only supports primary methods."
-  ^MethodCombination []
+  []
   (combo.clojure/->ClojureMethodCombination))
 
 (defn clos-method-combination
@@ -34,19 +33,19 @@
   Supports `:before`, `:after`, and `:around` auxiliary methods. The values returned by `:before` and `:after` methods
   are ignored. Primary methods and around methods get an implicit `next-method` arg (see Methodical dox for more on
   what this means)."
-  ^MethodCombination []
+  []
   (combo.clos/->CLOSStandardMethodCombination))
 
 (defn thread-first-method-combination
   "Similar the the standard CLOS-style method combination, but threads the result of each `:before` and `:after`
   auxiliary methods, as well as the primary method, as the *first* arg of subsequent method invocations."
-  ^MethodCombination []
+  []
   (combo.threaded/threading-method-combination :thread-first))
 
 (defn thread-last-method-combination
   "Similar the the standard CLOS-style method combination, but threads the result of each `:before` and `:after`
   auxiliary methods, as well as the primary method, as the *last* arg of subsequent method invocations."
-  ^MethodCombination []
+  []
   (combo.threaded/threading-method-combination :thread-last))
 
 
@@ -70,26 +69,26 @@
   "Based on the CLOS `progn` method combination. Sequentially executes *all* applicable primary methods, presumably for
   side-effects, in order from most-specific to least-specific; returns the value returned by the least-specific
   method. `do` method combinations support `:around` auxiliary methods, but not `:before` or `:after` methods."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :do))
 
 (defn min-method-combination
   "Based on the CLOS method combination of the same name. Executes *all* applicable primary methods, returning the
   minimum value returned by any implementation. Like `do` method combinations, `min` supports `:around` auxiliary
   methods, but not `:before` or `:after`."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :min))
 
 (defn max-method-combination
   "Executes *all* applicable primary methods, and returns the maximum value returned by any one implemenation. Same
   constraints as othe CLOS operator-style method combinations."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :max))
 
 (defn +-method-combination
   "Executes *all* applicable primary methods, returnings the sum of the values returned by each method. Same constraints
   as othe CLOS operator-style method combinations."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :+))
 
 (defn seq-method-combination
@@ -97,14 +96,14 @@
   the method invocations. Inspired by CLOS `nconc` and `append` method combinations, but unlike those, this
   combination returns a completely lazy sequence. Like other CLOS-operator-inspired method combinations, this
   combination currently supports `:around` methods, but not `:before` or `:after` methods."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :seq))
 
 (defn concat-method-combination
   "Like the `seq-method-combination`, but concatenates all the results together.
 
     seq-method-combination : map :: concat-method-combination : mapcat"
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :concat))
 
 
@@ -112,13 +111,13 @@
   "Invoke *all* applicable primary methods, from most-specific to least-specific; reducing the results as if by `and`.
   Like `and`, this method invocation short-circuits if any implementation returns a falsey value. Otherwise, this
   method returns the value returned by the last method invoked."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :and))
 
 (defn or-method-combination
   "Like the `and` combination, but combines result as if by `or`; short-circuits after the first matching primary method
   returns a truthy value."
-  ^MethodCombination []
+  []
   (combo.operator/operator-method-combination :or))
 
 
@@ -129,10 +128,10 @@
   multimethods handle multimethod dispatch, with support for a custom `hierarchy`, `default-value` and map of
   `prefers`."
   {:style/indent 1}
-  ^Dispatcher [dispatch-fn & {:keys [hierarchy default-value prefers]
-                              :or   {hierarchy     #'clojure.core/global-hierarchy
-                                     default-value :default
-                                     prefers       {}}}]
+  [dispatch-fn & {:keys [hierarchy default-value prefers]
+                  :or   {hierarchy     #'clojure.core/global-hierarchy
+                         default-value :default
+                         prefers       {}}}]
   {:pre [(ifn? dispatch-fn) (var? hierarchy) (map? prefers)]}
   (dispatcher.standard/->StandardDispatcher dispatch-fn hierarchy default-value prefers))
 
@@ -140,9 +139,9 @@
   "A Dispatcher that always considers *all* primary and auxiliary methods to be matches; does not calculate dispatch
   values for arguments when invoking. Dispatch values are still used to sort methods from most- to least- specific,
   using `hierarchy` and map of `prefers`."
-  ^Dispatcher [& {:keys [hierarchy prefers]
-                  :or   {hierarchy #'clojure.core/global-hierarchy
-                         prefers   {}}}]
+  [& {:keys [hierarchy prefers]
+      :or   {hierarchy #'clojure.core/global-hierarchy
+             prefers   {}}}]
   (dispatcher.everything/->EverythingDispatcher hierarchy prefers))
 
 
@@ -150,20 +149,20 @@
 
 (defn clojure-method-table
   "Create a new Clojure-style method table. Clojure-style method tables only support primary methods."
-  (^MethodTable  []
+  ([]
    (clojure-method-table {}))
 
-  (^MethodTable [m]
+  ([m]
    {:pre [(map? m)]}
    (method-table.clojure/->ClojureMethodTable m)))
 
 
 (defn standard-method-table
   "Create a new standard method table that supports both primary and auxiliary methods."
-  (^MethodTable []
+  ([]
    (standard-method-table {} {}))
 
-  (^MethodTable [primary aux]
+  ([primary aux]
    {:pre [(map? primary) (map? aux)]}
    (method-table.standard/->StandardMethodTable primary aux)))
 
@@ -172,17 +171,17 @@
 
 (defn simple-cache
   "Create a basic dumb cache. The simple cache stores"
-  (^Cache []
+  ([]
    (simple-cache {}))
 
-  (^Cache [m]
+  ([m]
    (cache.simple/->SimpleCache (atom m))))
 
 (defn watching-cache
   "Wrap `cache` in a `WatchingCache`, which clears the cache whenever one of the watched `references` (such as vars or
   atoms) changes. Intended primarily for use with 'permanent' MultiFns, such as those created with `defmulti`; this is
   rarely needed or wanted for transient multifns."
-  ^Cache [cache references]
+  [cache references]
   (cache.watching/add-watches cache references))
 
 
@@ -190,16 +189,16 @@
 
 (defn standard-multifn-impl
   "Create a basic multifn impl using method combination `combo`, dispatcher `dispatcher`, and `method-table`."
-  ^MultiFnImpl [combo dispatcher method-table]
-  {:pre [(instance? MethodCombination combo)
-         (instance? Dispatcher dispatcher)
-         (instance? MethodTable method-table)]}
+  [combo dispatcher method-table]
+  {:pre [(satisfies? i/MethodCombination combo)
+         (satisfies? i/Dispatcher dispatcher)
+         (satisfies? i/MethodTable method-table)]}
   (multifn.standard/->StandardMultiFnImpl combo dispatcher method-table))
 
 (defn default-multifn-impl
   "Create a basic multifn impl using default choices for method combination, dispatcher, and method table."
   {:arglists '([dispatch-fn & {:keys [hierarchy default-value prefers]}])}
-  ^MultiFnImpl [dispatch-fn & dispatcher-options]
+  [dispatch-fn & dispatcher-options]
   (standard-multifn-impl
    (thread-last-method-combination)
    (apply standard-dispatcher dispatch-fn dispatcher-options)
@@ -208,7 +207,7 @@
 (defn clojure-multifn-impl
   "Create a mulitfn impl that largely behaves the same way as a vanilla Clojure multimethod."
   {:arglists '([dispatch-fn & {:keys [hierarchy default-value prefers method-table]}])}
-  ^MultiFnImpl [dispatch-fn & {:keys [method-table], :or {method-table {}}, :as options}]
+  [dispatch-fn & {:keys [method-table], :or {method-table {}}, :as options}]
   (let [dispatcher-options (apply concat (select-keys options [:hierarchy :default-value :prefers]))]
     (standard-multifn-impl
      (clojure-method-combination)
@@ -221,9 +220,9 @@
   `:before` and `:after` methods are ignored, rather than threaded. Primary and `:around` methods each get an implicit
   `next-method` arg."
   {:arglists '([dispatch-fn & {:keys [hierarchy default-value prefers primary-method-table aux-method-table]}])}
-  ^MultiFnImpl [dispatch-fn & {:keys [primary-method-table aux-method-table],
-                                     :or   {primary-method-table {}, aux-method-table {}}
-                                     :as   options}]
+  [dispatch-fn & {:keys [primary-method-table aux-method-table],
+                  :or   {primary-method-table {}, aux-method-table {}}
+                  :as   options}]
   (let [dispatcher-options (apply concat (select-keys options [:hierarchy :default-value :prefers]))]
     (standard-multifn-impl
      (clos-method-combination)
@@ -233,10 +232,10 @@
 (defn cached-multifn-impl
   "Wrap a `MultiFnImpl` in a `CachedMultiFnImpl`, which adds caching to calculated effective methods. The cache itself
   is swappable with other caches that implement different strategies."
-  (^MultiFnImpl [impl]
+  ([impl]
    (cached-multifn-impl impl (simple-cache)))
 
-  (^MultiFnImpl [impl cache]
+  ([impl cache]
    (multifn.cached/->CachedMultiFnImpl impl cache)))
 
 
@@ -245,21 +244,21 @@
 (defn uncached-multifn
   "Create a new Methodical multifn using `impl` as the multifn implementation; `impl` itself should implement
   `MultiFnImpl`. DOES NOT CACHE EFFECTIVE METHODS -- use `multifn` instead, unless you like slow dispatch times."
-  (^StandardMultiFn [impl]
+  ([impl]
    (uncached-multifn impl nil))
 
-  (^StandardMultiFn [impl mta]
+  ([impl mta]
    (impl.standard/->StandardMultiFn impl mta)))
 
 (defn multifn
   "Create a new *cached* Methodical multifn using `impl` as the multifn implementation."
-  (^StandardMultiFn [impl]
+  ([impl]
    (multifn impl nil))
 
-  (^StandardMultiFn [impl mta]
+  ([impl mta]
    (multifn impl mta (simple-cache)))
 
-  (^StandardMultiFn [impl mta cache]
+  ([impl mta cache]
    (uncached-multifn (cached-multifn-impl impl cache) mta)))
 
 (def ^{:arglists (:arglists (meta #'default-multifn-impl))}

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -2,15 +2,15 @@
   "A basic, dumb cache. `SimpleCache` stores cached methods in a simple map of dispatch-value -> effective method; it
   offers no facilities to deduplicate identical methods for the same dispatch value. This behaves similarly to the
   caching mechanism in vanilla Clojure."
-  (:require [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.Cache))
+  (:require [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (deftype SimpleCache [atomm]
   PrettyPrintable
   (pretty [_]
     '(simple-cache))
 
-  Cache
+  i/Cache
   (cached-method [_ dispatch-value]
     (get @atomm dispatch-value))
 

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -2,11 +2,10 @@
   "A basic, dumb cache. `SimpleCache` stores cached methods in a simple map of dispatch-value -> effective method; it
   offers no facilities to deduplicate identical methods for the same dispatch value. This behaves similarly to the
   caching mechanism in vanilla Clojure."
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Cache))
 
-(p.types/deftype+ SimpleCache [atomm]
+(deftype SimpleCache [atomm]
   PrettyPrintable
   (pretty [_]
     '(simple-cache))

--- a/src/methodical/impl/cache/watching.clj
+++ b/src/methodical/impl/cache/watching.clj
@@ -12,14 +12,13 @@
   finalized (which, of course, may actually be never -- but worst-case is that some unneeded calls to `clear-cache!`
   get made)."
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import java.lang.ref.WeakReference
            methodical.interface.Cache))
 
 (declare add-watches remove-watches)
 
-(p.types/deftype+ WatchingCache [^Cache cache watch-key refs]
+(deftype WatchingCache [^Cache cache watch-key refs]
   PrettyPrintable
   (pretty [_]
     (concat ['watching-cache cache 'watching] refs))

--- a/src/methodical/impl/cache/watching.clj
+++ b/src/methodical/impl/cache/watching.clj
@@ -13,12 +13,11 @@
   get made)."
   (:require [methodical.interface :as i]
             [pretty.core :refer [PrettyPrintable]])
-  (:import java.lang.ref.WeakReference
-           methodical.interface.Cache))
+  (:import java.lang.ref.WeakReference))
 
 (declare add-watches remove-watches)
 
-(deftype WatchingCache [^Cache cache watch-key refs]
+(deftype WatchingCache [cache watch-key refs]
   PrettyPrintable
   (pretty [_]
     (concat ['watching-cache cache 'watching] refs))
@@ -27,7 +26,7 @@
   (finalize [this]
     (remove-watches this))
 
-  Cache
+  i/Cache
   (cached-method [_ dispatch-value]
     (.cached-method cache dispatch-value))
 
@@ -50,7 +49,7 @@
           (i/clear-cache! cache))))))
 
 (defn- new-cache-with-watches
-  ^WatchingCache [^Cache wrapped-cache watch-key refs]
+  ^WatchingCache [wrapped-cache watch-key refs]
   (let [cache    (WatchingCache. wrapped-cache watch-key (set refs))
         watch-fn (cache-watch-fn cache)]
     (doseq [reference refs]
@@ -66,7 +65,7 @@
 
   * If `cache` is a WatchingCache with a *different* set of refs, this returns a flattened WatchingCache that both the
     orignal refs and the new ones. The original `cache` is unmodified."
-  ^Cache [^Cache cache refs]
+  [cache refs]
   {:pre [(every? (partial instance? clojure.lang.IRef) refs)]}
   (cond
     (empty? refs)

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -1,11 +1,10 @@
 (ns methodical.impl.combo.clojure
   "Simple method combination strategy that mimics the way vanilla Clojure multimethods combine methods; that is, to say,
   not at all. Like vanilla Clojure multimethods, this method combination only supports primary methods."
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
-(p.types/deftype+ ClojureMethodCombination []
+(deftype ClojureMethodCombination []
   PrettyPrintable
   (pretty [_]
     '(clojure-method-combination))

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -1,8 +1,8 @@
 (ns methodical.impl.combo.clojure
   "Simple method combination strategy that mimics the way vanilla Clojure multimethods combine methods; that is, to say,
   not at all. Like vanilla Clojure multimethods, this method combination only supports primary methods."
-  (:require [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodCombination))
+  (:require [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (deftype ClojureMethodCombination []
   PrettyPrintable
@@ -13,7 +13,7 @@
   (equals [_ another]
     (instance? ClojureMethodCombination another))
 
-  MethodCombination
+  i/MethodCombination
   (allowed-qualifiers [_]
     #{nil}) ; only primary methods
 

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -4,7 +4,6 @@
   are ignored. Primary methods and around methods get an implicit `next-method` arg (see Methodical dox for more on
   what this means)."
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -53,7 +52,7 @@
                          result)]
       (comp apply-afters combined-method))))
 
-(p.types/deftype+ CLOSStandardMethodCombination []
+(deftype CLOSStandardMethodCombination []
   PrettyPrintable
   (pretty [_]
     '(clos-method-combination))

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -4,8 +4,8 @@
   are ignored. Primary methods and around methods get an implicit `next-method` arg (see Methodical dox for more on
   what this means)."
   (:require [methodical.impl.combo.common :as combo.common]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodCombination))
+            [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 ;; TODO - I'm 90% sure we can leverage the `reducing-operator` stuff in `combo.operator` to implemet this
 (defn- apply-befores [combined-method befores]
@@ -61,7 +61,7 @@
   (equals [_ another]
     (instance? CLOSStandardMethodCombination another))
 
-  MethodCombination
+  i/MethodCombination
   (allowed-qualifiers [_]
     #{nil :before :after :around})
 

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -38,7 +38,6 @@
       ...)"
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -152,7 +151,7 @@
 
 ;;;; ### `OperatorMethodCombination`
 
-(p.types/deftype+ OperatorMethodCombination [operator-name]
+(deftype OperatorMethodCombination [operator-name]
   PrettyPrintable
   (pretty [_]
     (list 'operator-method-combination operator-name))

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -38,8 +38,8 @@
       ...)"
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodCombination))
+            [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (defmulti operator
   "Define a new operator that can be used as part of an `OperatorMethodCombination`. See examples below for more
@@ -161,7 +161,7 @@
     (and (instance? OperatorMethodCombination another)
          (= operator-name (.operator-name ^OperatorMethodCombination another))))
 
-  MethodCombination
+  i/MethodCombination
   (allowed-qualifiers [_]
     #{nil :around})
 

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -1,8 +1,8 @@
 (ns methodical.impl.combo.threaded
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodCombination))
+            [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (defn reducer-fn
   "Reduces a series of before/combined-primary/after methods, threading the resulting values to the next method by
@@ -74,13 +74,12 @@
   (pretty [_]
     (list 'threading-method-combination threading-type))
 
-  MethodCombination
   Object
   (equals [_ another]
     (and (instance? ThreadingMethodCombination another)
          (= threading-type (.threading-type ^ThreadingMethodCombination another))))
 
-  MethodCombination
+  i/MethodCombination
   (allowed-qualifiers [_]
     #{nil :before :after :around})
 

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -1,7 +1,6 @@
 (ns methodical.impl.combo.threaded
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -70,7 +69,7 @@
           (apply method (conj butlast* last*)))]))))
 
 
-(p.types/deftype+ ThreadingMethodCombination [threading-type]
+(deftype ThreadingMethodCombination [threading-type]
   PrettyPrintable
   (pretty [_]
     (list 'threading-method-combination threading-type))

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -1,11 +1,10 @@
 (ns methodical.impl.dispatcher.everything
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Dispatcher))
 
-(p.types/deftype+ EverythingDispatcher [hierarchy-var prefs]
+(deftype EverythingDispatcher [hierarchy-var prefs]
   PrettyPrintable
   (pretty [_]
     (cons

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -1,8 +1,8 @@
 (ns methodical.impl.dispatcher.everything
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.Dispatcher))
+            [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (deftype EverythingDispatcher [hierarchy-var prefs]
   PrettyPrintable
@@ -24,7 +24,7 @@
         (= hierarchy-var (.hierarchy-var another))
         (= prefs (.prefs another))))))
 
-  Dispatcher
+  i/Dispatcher
   (dispatch-value [_]              nil)
   (dispatch-value [_ a]            nil)
   (dispatch-value [_ a b]          nil)

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -4,8 +4,7 @@
   (:refer-clojure :exclude [prefers prefer-method])
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.Dispatcher))
+            [pretty.core :refer [PrettyPrintable]]))
 
 (defn- matching-primary-pairs-excluding-default
   "Return a sequence of pairs of `[dispatch-value method]` for all applicable dispatch values, excluding the default
@@ -109,7 +108,7 @@
         (= default-value (.default-value another))
         (= prefs (.prefs another))))))
 
-  Dispatcher
+  i/Dispatcher
   (dispatch-value [_]              (dispatch-fn))
   (dispatch-value [_ a]            (dispatch-fn a))
   (dispatch-value [_ a b]          (dispatch-fn a b))

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -4,7 +4,6 @@
   (:refer-clojure :exclude [prefers prefer-method])
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Dispatcher))
 
@@ -88,7 +87,7 @@
              [qualifier (map second pairs)])))
 
 
-(p.types/deftype+ StandardDispatcher [dispatch-fn hierarchy-var default-value prefs]
+(deftype StandardDispatcher [dispatch-fn hierarchy-var default-value prefs]
   PrettyPrintable
   (pretty [_]
     (concat ['standard-dispatcher dispatch-fn]

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -1,6 +1,6 @@
 (ns methodical.impl.method-table.clojure
-  (:require [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodTable))
+  (:require [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (deftype ClojureMethodTable [m]
   PrettyPrintable
@@ -14,7 +14,7 @@
     (and (instance? ClojureMethodTable another)
          (= m (.m ^ClojureMethodTable another))))
 
-  MethodTable
+  i/MethodTable
   (primary-methods [_]
     m)
 

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -1,9 +1,8 @@
 (ns methodical.impl.method-table.clojure
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 
-(p.types/deftype+ ClojureMethodTable [m]
+(deftype ClojureMethodTable [m]
   PrettyPrintable
   (pretty [_]
     (if (seq m)

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -1,9 +1,8 @@
 (ns methodical.impl.method-table.standard
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 
-(p.types/deftype+ StandardMethodTable [primary aux]
+(deftype StandardMethodTable [primary aux]
   PrettyPrintable
   (pretty [_]
     (cons

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -1,6 +1,6 @@
 (ns methodical.impl.method-table.standard
-  (:require [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.MethodTable))
+  (:require [pretty.core :refer [PrettyPrintable]]
+            [methodical.interface :as i]))
 
 (deftype StandardMethodTable [primary aux]
   PrettyPrintable
@@ -22,7 +22,7 @@
          (= primary (.primary ^StandardMethodTable another))
          (= aux (.aux ^StandardMethodTable another))))
 
-  MethodTable
+  i/MethodTable
   (primary-methods [_]
     primary)
 

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -1,10 +1,9 @@
 (ns methodical.impl.multifn.cached
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Cache MultiFnImpl]))
 
-(p.types/deftype+ CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
+(deftype CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
   PrettyPrintable
   (pretty [_]
     (list 'cached-multifn-impl impl cache))

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -1,9 +1,8 @@
 (ns methodical.impl.multifn.cached
   (:require [methodical.interface :as i]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import [methodical.interface Cache MultiFnImpl]))
+            [pretty.core :refer [PrettyPrintable]]))
 
-(deftype CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
+(deftype CachedMultiFnImpl [impl cache]
   PrettyPrintable
   (pretty [_]
     (list 'cached-multifn-impl impl cache))
@@ -15,7 +14,7 @@
          ;; TODO - does this make sense?
          (= (class cache) (class (.cache ^CachedMultiFnImpl another)))))
 
-  MultiFnImpl
+  i/MultiFnImpl
   (method-combination [_]
     (i/method-combination impl))
 

--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -1,7 +1,6 @@
 (ns methodical.impl.multifn.standard
   "Standard Methodical MultiFn impl, which "
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
@@ -13,9 +12,9 @@
         aux-methods     (i/matching-aux-methods dispatcher method-table dispatch-value)]
     (i/combine-methods method-combination primary-methods aux-methods)))
 
-(p.types/deftype+ StandardMultiFnImpl [^MethodCombination combo
-                                       ^Dispatcher dispatcher
-                                       ^MethodTable method-table]
+(deftype StandardMultiFnImpl [^MethodCombination combo
+                              ^Dispatcher dispatcher
+                              ^MethodTable method-table]
   PrettyPrintable
   (pretty [_]
     (list 'standard-multifn-impl combo dispatcher method-table))

--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -1,8 +1,7 @@
 (ns methodical.impl.multifn.standard
   "Standard Methodical MultiFn impl, which "
   (:require [methodical.interface :as i]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
+            [pretty.core :refer [PrettyPrintable]]))
 
 (defn standard-effective-method
   "Build an effective method using the 'standard' technique, taking the dispatch-value-method pairs in the
@@ -12,9 +11,7 @@
         aux-methods     (i/matching-aux-methods dispatcher method-table dispatch-value)]
     (i/combine-methods method-combination primary-methods aux-methods)))
 
-(deftype StandardMultiFnImpl [^MethodCombination combo
-                              ^Dispatcher dispatcher
-                              ^MethodTable method-table]
+(deftype StandardMultiFnImpl [combo dispatcher method-table]
   PrettyPrintable
   (pretty [_]
     (list 'standard-multifn-impl combo dispatcher method-table))
@@ -22,12 +19,11 @@
   Object
   (equals [_ another]
     (and (instance? StandardMultiFnImpl another)
-         (let [^StandardMultiFnImpl another another]
-           (and (= combo (.combo another))
-                (= dispatcher (.dispatcher another))
-                (= method-table (.method-table another))))))
+         (and (= combo (.combo another))
+              (= dispatcher (.dispatcher another))
+              (= method-table (.method-table another)))))
 
-  MultiFnImpl
+  i/MultiFnImpl
   (method-combination [_]
     combo)
 

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -1,6 +1,5 @@
 (ns methodical.impl.standard
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
@@ -27,7 +26,7 @@
   ([^MultiFnImpl impl a b c d & more]
    (apply (effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d more)) a b c d more)))
 
-(p.types/deftype+ StandardMultiFn [^MultiFnImpl impl mta]
+(deftype StandardMultiFn [^MultiFnImpl impl mta]
   PrettyPrintable
   (pretty [_]
     (list 'multifn impl))

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -1,8 +1,7 @@
 (ns methodical.interface
-  (:refer-clojure :exclude [isa? prefers prefer-method])
-  (:require [potemkin.types :as p.types]))
+  (:refer-clojure :exclude [isa? prefers prefer-method]))
 
-(p.types/definterface+ MethodCombination
+(defprotocol MethodCombination
   (allowed-qualifiers [method-combination]
     "The set containg all qualifiers supported by this method combination. `nil` in the set means the method
     combination supports primary methods (because primary methods have no qualifier); all other values refer to
@@ -22,7 +21,7 @@
     `next-method` to the body of a `defmethod` macro. (Because this method is invoked during macroexpansion, it should
     return a Clojure form.)"))
 
-(p.types/definterface+ MethodTable
+(defprotocol MethodTable
   (primary-methods [method-table]
     "Get a `dispatch-value -> fn` map of all primary methods assoicated with this method table.")
 
@@ -47,7 +46,7 @@
 
     In the future, I hope to fix this by storing unique indentifiers in the metadata of methods in the map."))
 
-(p.types/definterface+ Dispatcher
+(defprotocol Dispatcher
   (dispatch-value
     [dispatcher]
     [dispatcher a]
@@ -77,7 +76,7 @@
     "Prefer `dispatch-val-x` over `dispatch-val-y` for dispatch and method combinations."))
 
 
-(p.types/definterface+ MultiFnImpl
+(defprotocol MultiFnImpl
   (^methodical.interface.MethodCombination method-combination [multifn]
     "Get the method combination associated with this multifn.")
 
@@ -99,7 +98,7 @@
     to `get-method` in vanilla Clojure multimethods; a different name is used here because I felt `get-method` would
     be ambiguous with regards to whether it returns only a primary method or a combined effective method."))
 
-(p.types/definterface+ Cache
+(defprotocol Cache
   (cached-method [cache dispatch-value]
     "Return cached effective method for `dispatch-value`, if it exists in the cache.")
 

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -77,19 +77,19 @@
 
 
 (defprotocol MultiFnImpl
-  (^methodical.interface.MethodCombination method-combination [multifn]
+  (method-combination [multifn]
     "Get the method combination associated with this multifn.")
 
-  (^methodical.interface.Dispatcher dispatcher [multifn]
+  (dispatcher [multifn]
     "Get the dispatcher associated with this multifn.")
 
-  (^methodical.interface.MultiFnImpl with-dispatcher [multifn new-dispatcher]
+  (with-dispatcher [multifn new-dispatcher]
     "Return a copy of this multifn using `new-dispatcher` as its dispatcher.")
 
-  (^methodical.interface.MethodTable method-table [multifn]
+  (method-table [multifn]
     "Get the method table associated with this multifn.")
 
-  (^methodical.interface.MultiFnImpl with-method-table [multifn new-method-table]
+  (with-method-table [multifn new-method-table]
     "Return a copy of this multifn using `new-method-table` as its method table.")
 
   (effective-method [multifn dispatch-value]

--- a/test/methodical/impl/dispatcher/standard_test.clj
+++ b/test/methodical/impl/dispatcher/standard_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [methodical
              [impl :as impl]
-             [interface :as i]])
-  (:import methodical.interface.MethodTable))
+             [interface :as i]]))
 
 (deftest equality-test
   (is (= (impl/standard-dispatcher keyword)
@@ -14,7 +13,7 @@
       "Two standard dispatchers with different args should *not* be considered equal."))
 
 (defn- method-table [primary-methods aux-methods]
-  (reify MethodTable
+  (reify i/MethodTable
     (primary-methods [_] primary-methods)
     (aux-methods [_] aux-methods)))
 


### PR DESCRIPTION
Benchmark for #20. 

+ `definterface` => `defprotocol`
+ `deftype+` => `deftype`
+ remove type hints
+ direct calls => protocol calls

Benchmark
+ simple: 238,312268 ns vs 4,945147 µs   **x10**
+ big-hierarchy: 19,027996 ns vs 2,401364 µs **x100**
+ big-hierarchy +clojure: 16,850978 ns vs 1,476671 µs  **x100**

May be it is possible to preserve type hints in clojurescript and save some performance.

Is it reasonable price for clojurescript?
