### PR TITLE
prefers? should check ancestors; remove util/prefers?

### DIFF
--- a/src/methodical/core.clj
+++ b/src/methodical/core.clj
@@ -94,7 +94,6 @@
   add-aux-method-with-unique-key
   remove-aux-method-with-unique-key
   remove-all-methods
-  prefers?
   ;; destructive ops
   add-primary-method!
   remove-primary-method!

--- a/src/methodical/util.clj
+++ b/src/methodical/util.clj
@@ -148,18 +148,6 @@
   [multifn]
   (-> multifn remove-all-primary-methods remove-all-aux-methods))
 
-(defn prefers?
-  "Does this multifn's dispatcher have an *explict* preference specified (i.e., via `prefer-method`) for
-  `dispatch-val-x` over `dispatch-val-y`?"
-  [multifn dispatch-val-x dispatch-val-y]
-  (boolean
-   (when-let [preferences (get (i/prefers multifn) dispatch-val-x)]
-     (or (contains? preferences dispatch-val-y)
-         (some
-          (fn [pref]
-            (prefers? multifn pref dispatch-val-y))
-          preferences)))))
-
 
 ;;;; #### Low-level destructive operations
 

--- a/test/methodical/impl/dispatcher/common_test.clj
+++ b/test/methodical/impl/dispatcher/common_test.clj
@@ -1,0 +1,21 @@
+(ns methodical.impl.dispatcher.common-test
+  (:require [clojure.test :refer :all]
+            [methodical.impl.dispatcher.common :as dispatcher.common]))
+
+(deftest prefers-test
+  (testing "prefers?"
+    (let [h (-> (make-hierarchy)
+                (derive :x :x-parent)
+                (derive :y :y-parent))]
+      (are [msg prefs] (testing (format "x should be preferred over y with prefers = %s" prefs)
+                         (is (= true
+                                (dispatcher.common/prefers? h prefs :x :y))
+                             msg))
+        "x is directly preferred over y"
+        {:x #{:y}}
+        "x is preferred over an ancestor of y"
+        {:x #{:y-parent}}
+        "an ancestor of x is preferred over y"
+        {:x-parent #{:y}}
+        "an ancestor of x is preferred over an ancestor of y"
+        {:x-parent #{:y-parent}}))))

--- a/test/methodical/util_test.clj
+++ b/test/methodical/util_test.clj
@@ -261,31 +261,3 @@
 
       (is (= nil
              (seq (i/aux-methods remove-all-methods-multifn)))))))
-
-(deftest prefers-test
-  (testing "prefers?"
-    (let [f (-> (m/default-multifn keyword)
-                (m/prefer-method :x :y)
-                (m/prefer-method :y :z))]
-      (is (= true
-             (u/prefers? f :x :y))
-          "prefers? should handle direct preferences")
-
-      (is (= true
-             (u/prefers? f :x :z))
-          "prefers? shoud handle indirect preferences")
-
-      (is (= false
-             (u/prefers? f :y :x)))
-
-      (is (= false
-             (u/prefers? f :z :x)))))
-
-  (testing "prefer-method!"
-    (def prefer-method-multifn nil)
-    (m/defmulti prefer-method-multifn keyword)
-
-    (u/prefer-method! #'prefer-method-multifn :x :y)
-
-    (is (= {:x #{:y}}
-           (m/prefers prefer-method-multifn)))))


### PR DESCRIPTION
Fixes #22 and #23. Also addresses an issue present in vanilla Clojure mulitmethods: https://clojure.atlassian.net/browse/CLJ-2234