### PR TITLE
Interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /tags
 /target
 \#*\#
+/.cljs_node_repl

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
 
   :dependencies
   [[pretty "1.0.0"]
-   [potemkin "0.4.5"]]
+   [potemkin "0.4.5"]
+   [org.clojure/clojurescript "1.10.520" :scope "provided"]]
 
   :aot [methodical.interface methodical.impl.standard]
 

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -2,11 +2,10 @@
   "A basic, dumb cache. `SimpleCache` stores cached methods in a simple map of dispatch-value -> effective method; it
   offers no facilities to deduplicate identical methods for the same dispatch value. This behaves similarly to the
   caching mechanism in vanilla Clojure."
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Cache))
 
-(p.types/deftype+ SimpleCache [atomm]
+(deftype SimpleCache [atomm]
   PrettyPrintable
   (pretty [_]
     '(simple-cache))

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -12,15 +12,15 @@
     '(simple-cache))
 
   Cache
-  (cached-method [_ dispatch-value]
+  (cachedMethod [_ dispatch-value]
     (get @atomm dispatch-value))
 
-  (cache-method! [_ dispatch-value method]
+  (cacheMethodBang [_ dispatch-value method]
     (swap! atomm assoc dispatch-value method))
 
-  (clear-cache! [this]
+  (clearCacheBang [this]
     (reset! atomm {})
     this)
 
-  (empty-copy [this]
+  (emptyCopy [this]
     (SimpleCache. (atom {}))))

--- a/src/methodical/impl/cache/watching.clj
+++ b/src/methodical/impl/cache/watching.clj
@@ -12,14 +12,13 @@
   finalized (which, of course, may actually be never -- but worst-case is that some unneeded calls to `clear-cache!`
   get made)."
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import java.lang.ref.WeakReference
            methodical.interface.Cache))
 
 (declare add-watches remove-watches)
 
-(p.types/deftype+ WatchingCache [^Cache cache watch-key refs]
+(deftype WatchingCache [^Cache cache watch-key refs]
   PrettyPrintable
   (pretty [_]
     (concat ['watching-cache cache 'watching] refs))

--- a/src/methodical/impl/cache/watching.clj
+++ b/src/methodical/impl/cache/watching.clj
@@ -29,18 +29,18 @@
     (remove-watches this))
 
   Cache
-  (cached-method [_ dispatch-value]
-    (.cached-method cache dispatch-value))
+  (cachedMethod [_ dispatch-value]
+    (.cachedMethod cache dispatch-value))
 
-  (cache-method! [this dispatch-value method]
-    (.cache-method! cache dispatch-value method)
+  (cacheMethodBang [this dispatch-value method]
+    (.cacheMethodBang cache dispatch-value method)
     this)
 
-  (clear-cache! [this]
-    (.clear-cache! cache)
+  (clearCacheBang [this]
+    (.clearCacheBang cache)
     this)
 
-  (empty-copy [this]
+  (emptyCopy [this]
     (add-watches (i/empty-copy cache) refs)))
 
 (defn- cache-watch-fn [cache]

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -1,11 +1,10 @@
 (ns methodical.impl.combo.clojure
   "Simple method combination strategy that mimics the way vanilla Clojure multimethods combine methods; that is, to say,
   not at all. Like vanilla Clojure multimethods, this method combination only supports primary methods."
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
-(p.types/deftype+ ClojureMethodCombination []
+(deftype ClojureMethodCombination []
   PrettyPrintable
   (pretty [_]
     '(clojure-method-combination))

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -15,13 +15,13 @@
     (instance? ClojureMethodCombination another))
 
   MethodCombination
-  (allowed-qualifiers [_]
+  (allowedQualifiers [_]
     #{nil}) ; only primary methods
 
-  (combine-methods [_ [primary-method] aux-methods]
+  (combineMethods [_ [primary-method] aux-methods]
     (when (seq aux-methods)
       (throw (UnsupportedOperationException. "Clojure-style multimethods do not support auxiliary methods.")))
     primary-method)
 
-  (transform-fn-tail [_ _ fn-tail]
+  (transformFnTail [_ _ fn-tail]
     fn-tail))

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -4,7 +4,6 @@
   are ignored. Primary methods and around methods get an implicit `next-method` arg (see Methodical dox for more on
   what this means)."
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -53,7 +52,7 @@
                          result)]
       (comp apply-afters combined-method))))
 
-(p.types/deftype+ CLOSStandardMethodCombination []
+(deftype CLOSStandardMethodCombination []
   PrettyPrintable
   (pretty [_]
     '(clos-method-combination))

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -63,14 +63,14 @@
     (instance? CLOSStandardMethodCombination another))
 
   MethodCombination
-  (allowed-qualifiers [_]
+  (allowedQualifiers [_]
     #{nil :before :after :around})
 
-  (combine-methods [_ primary-methods {:keys [before after around]}]
+  (combineMethods [_ primary-methods {:keys [before after around]}]
     (some-> (combo.common/combine-primary-methods primary-methods)
             (apply-befores before)
             (apply-afters after)
             (combo.common/apply-around-methods around)))
 
-  (transform-fn-tail [_ qualifier fn-tail]
+  (transformFnTail [_ qualifier fn-tail]
     (combo.common/add-implicit-next-method-args qualifier fn-tail)))

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -38,7 +38,6 @@
       ...)"
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -152,7 +151,7 @@
 
 ;;;; ### `OperatorMethodCombination`
 
-(p.types/deftype+ OperatorMethodCombination [operator-name]
+(deftype OperatorMethodCombination [operator-name]
   PrettyPrintable
   (pretty [_]
     (list 'operator-method-combination operator-name))

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -163,15 +163,15 @@
          (= operator-name (.operator-name ^OperatorMethodCombination another))))
 
   MethodCombination
-  (allowed-qualifiers [_]
+  (allowedQualifiers [_]
     #{nil :around})
 
-  (combine-methods [_ primary-methods {:keys [around]}]
+  (combineMethods [_ primary-methods {:keys [around]}]
     (when (seq primary-methods)
       (-> ((operator operator-name) primary-methods)
           (combo.common/apply-around-methods around))))
 
-  (transform-fn-tail [_ qualifier fn-tail]
+  (transformFnTail [_ qualifier fn-tail]
     (if (= qualifier :around)
       (combo.common/add-implicit-next-method-args qualifier fn-tail)
       fn-tail)))

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -1,7 +1,6 @@
 (ns methodical.impl.combo.threaded
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 
@@ -70,7 +69,7 @@
           (apply method (conj butlast* last*)))]))))
 
 
-(p.types/deftype+ ThreadingMethodCombination [threading-type]
+(deftype ThreadingMethodCombination [threading-type]
   PrettyPrintable
   (pretty [_]
     (list 'threading-method-combination threading-type))

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -75,20 +75,19 @@
   (pretty [_]
     (list 'threading-method-combination threading-type))
 
-  MethodCombination
   Object
   (equals [_ another]
     (and (instance? ThreadingMethodCombination another)
          (= threading-type (.threading-type ^ThreadingMethodCombination another))))
 
   MethodCombination
-  (allowed-qualifiers [_]
+  (allowedQualifiers [_]
     #{nil :before :after :around})
 
-  (combine-methods [_ primary-methods aux-methods]
+  (combineMethods [_ primary-methods aux-methods]
     (combine-with-threader (threading-invoker threading-type) primary-methods aux-methods))
 
-  (transform-fn-tail [_ qualifier fn-tail]
+  (transformFnTail [_ qualifier fn-tail]
     (combo.common/add-implicit-next-method-args qualifier fn-tail)))
 
 (defn threading-method-combination

--- a/src/methodical/impl/dispatcher/common.cljc
+++ b/src/methodical/impl/dispatcher/common.cljc
@@ -1,5 +1,10 @@
 (ns methodical.impl.dispatcher.common
-  "Utility functions for implementing Dispatchers.")
+  "Utility functions for implementing Dispatchers."
+  #?(:cljs
+     (:require
+      [goog.string :refer [format]])))
+
+#?(:cljs (def ^:private IllegalStateException js/Error))
 
 (defn add-preference
   "Add a method preference to `prefs` for dispatch value `x` over `y`. Used to implement `prefer-method`."

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -1,11 +1,10 @@
 (ns methodical.impl.dispatcher.everything
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Dispatcher))
 
-(p.types/deftype+ EverythingDispatcher [hierarchy-var prefs]
+(deftype EverythingDispatcher [hierarchy-var prefs]
   PrettyPrintable
   (pretty [_]
     (cons

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -26,31 +26,31 @@
         (= prefs (.prefs another))))))
 
   Dispatcher
-  (dispatch-value [_]              nil)
-  (dispatch-value [_ a]            nil)
-  (dispatch-value [_ a b]          nil)
-  (dispatch-value [_ a b c]        nil)
-  (dispatch-value [_ a b c d]      nil)
-  (dispatch-value [_ a b c d more] nil)
+  (dispatchValue [_]              nil)
+  (dispatchValue [_ a]            nil)
+  (dispatchValue [_ a b]          nil)
+  (dispatchValue [_ a b c]        nil)
+  (dispatchValue [_ a b c d]      nil)
+  (dispatchValue [_ a b c d more] nil)
 
-  (matching-primary-methods [_ method-table _]
+  (matchingPrimaryMethods [_ method-table _]
     (let [primary-methods (i/primary-methods method-table)
           comparitor      (dispatcher.common/domination-comparitor (var-get hierarchy-var) prefs ::no-dispatch-value)]
       (map second (sort-by first comparitor primary-methods))))
 
-  (matching-aux-methods [_ method-table _]
+  (matchingAuxMethods [_ method-table _]
     (let [aux-methods (i/aux-methods method-table)
           comparitor  (dispatcher.common/domination-comparitor (var-get hierarchy-var) prefs ::no-dispatch-value)]
       (into {} (for [[qualifier dispatch-value->methods] aux-methods]
                  [qualifier (mapcat second (sort-by first comparitor dispatch-value->methods))]))))
 
-  (default-dispatch-value [_]
+  (defaultDispatchValue [_]
     nil)
 
   (prefers [_]
     prefs)
 
-  (prefer-method [this x y]
+  (preferMethod [this x y]
     (let [new-prefs (dispatcher.common/add-preference (partial isa? (var-get hierarchy-var)) prefs x y)]
       (if (= prefs new-prefs)
         this

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -111,26 +111,26 @@
         (= prefs (.prefs another))))))
 
   Dispatcher
-  (dispatch-value [_]              (dispatch-fn))
-  (dispatch-value [_ a]            (dispatch-fn a))
-  (dispatch-value [_ a b]          (dispatch-fn a b))
-  (dispatch-value [_ a b c]        (dispatch-fn a b c))
-  (dispatch-value [_ a b c d]      (dispatch-fn a b c d))
-  (dispatch-value [_ a b c d more] (apply dispatch-fn a b c d more))
+  (dispatchValue [_]              (dispatch-fn))
+  (dispatchValue [_ a]            (dispatch-fn a))
+  (dispatchValue [_ a b]          (dispatch-fn a b))
+  (dispatchValue [_ a b c]        (dispatch-fn a b c))
+  (dispatchValue [_ a b c d]      (dispatch-fn a b c d))
+  (dispatchValue [_ a b c d more] (apply dispatch-fn a b c d more))
 
-  (matching-primary-methods [_ method-table dispatch-value]
+  (matchingPrimaryMethods [_ method-table dispatch-value]
     (matching-primary-methods (var-get hierarchy-var) prefs default-value method-table dispatch-value))
 
-  (matching-aux-methods [_ method-table dispatch-value]
+  (matchingAuxMethods [_ method-table dispatch-value]
     (matching-aux-methods (var-get hierarchy-var) prefs default-value method-table dispatch-value))
 
-  (default-dispatch-value [_]
+  (defaultDispatchValue [_]
     default-value)
 
   (prefers [_]
     prefs)
 
-  (prefer-method [this x y]
+  (preferMethod [this x y]
     (let [new-prefs (dispatcher.common/add-preference (partial isa? (var-get hierarchy-var)) prefs x y)]
       (if (= prefs new-prefs)
         this

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -4,7 +4,6 @@
   (:refer-clojure :exclude [prefers prefer-method])
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Dispatcher))
 
@@ -88,7 +87,7 @@
              [qualifier (map second pairs)])))
 
 
-(p.types/deftype+ StandardDispatcher [dispatch-fn hierarchy-var default-value prefs]
+(deftype StandardDispatcher [dispatch-fn hierarchy-var default-value prefs]
   PrettyPrintable
   (pretty [_]
     (concat ['standard-dispatcher dispatch-fn]

--- a/src/methodical/impl/dispatcher/standard.cljc
+++ b/src/methodical/impl/dispatcher/standard.cljc
@@ -4,8 +4,12 @@
   (:refer-clojure :exclude [prefers prefer-method])
   (:require [methodical.impl.dispatcher.common :as dispatcher.common]
             [methodical.interface :as i]
-            [pretty.core :refer [PrettyPrintable]])
-  (:import methodical.interface.Dispatcher))
+            #?(:clj [pretty.core :refer [PrettyPrintable]])
+            #?(:cljs [methodical.interface :refer [Dispatcher]])
+            #?(:cljs [goog.string :refer [format]]))
+  #?(:clj (:import methodical.interface.Dispatcher)))
+
+#?(:cljs (def ^:private IllegalArgumentException js/Error))
 
 (defn- matching-primary-pairs-excluding-default
   "Return a sequence of pairs of `[dispatch-value method]` for all applicable dispatch values, excluding the default
@@ -86,20 +90,23 @@
                  :when       (seq pairs)]
              [qualifier (map second pairs)])))
 
-
 (deftype StandardDispatcher [dispatch-fn hierarchy-var default-value prefs]
-  PrettyPrintable
-  (pretty [_]
-    (concat ['standard-dispatcher dispatch-fn]
-            (when (not= hierarchy-var #'clojure.core/global-hierarchy)
-              [:hierarchy hierarchy-var])
-            (when (not= default-value :default)
-              [:default-value default-value])
-            (when (seq prefs)
-              [:prefers prefs])))
+  #?@(:clj
+      [PrettyPrintable
+       (pretty [_]
+               (concat ['standard-dispatcher dispatch-fn]
+                       (when (not= hierarchy-var #'clojure.core/global-hierarchy)
+                         [:hierarchy hierarchy-var])
+                       (when (not= default-value :default)
+                         [:default-value default-value])
+                       (when (seq prefs)
+                         [:prefers prefs])))])
 
-  Object
-  (equals [_ another]
+  #?(:clj  Object
+     :cljs IEquiv)
+  ;; todo: hashcode
+
+  (#?(:clj equals, :cljs -equiv) [_ another]
     (and
      (instance? StandardDispatcher another)
      (let [^StandardDispatcher another another]
@@ -109,7 +116,7 @@
         (= default-value (.default-value another))
         (= prefs (.prefs another))))))
 
-  Dispatcher
+  #?(:clj Dispatcher :cljs Object)
   (dispatchValue [_]              (dispatch-fn))
   (dispatchValue [_ a]            (dispatch-fn a))
   (dispatchValue [_ a b]          (dispatch-fn a b))
@@ -130,6 +137,8 @@
     prefs)
 
   (preferMethod [this x y]
+    ;; var-get is not implemented in cljs
+    ;; https://github.com/camsaul/methodical/issues/29
     (let [new-prefs (dispatcher.common/add-preference (partial isa? (var-get hierarchy-var)) prefs x y)]
       (if (= prefs new-prefs)
         this

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -1,9 +1,8 @@
 (ns methodical.impl.method-table.clojure
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 
-(p.types/deftype+ ClojureMethodTable [m]
+(deftype ClojureMethodTable [m]
   PrettyPrintable
   (pretty [_]
     (if (seq m)

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -16,26 +16,26 @@
          (= m (.m ^ClojureMethodTable another))))
 
   MethodTable
-  (primary-methods [_]
+  (primaryMethods [_]
     m)
 
-  (aux-methods [_]
+  (auxMethods [_]
     nil)
 
-  (add-primary-method [this dispatch-val method]
+  (addPrimaryMethod [this dispatch-val method]
     (let [new-m (assoc m dispatch-val method)]
       (if (= m new-m)
         this
         (ClojureMethodTable. new-m))))
 
-  (remove-primary-method [this dispatch-val]
+  (removePrimaryMethod [this dispatch-val]
     (let [new-m (dissoc m dispatch-val)]
       (if (= m new-m)
         this
         (ClojureMethodTable. new-m))))
 
-  (add-aux-method [_ _ _ _]
+  (addAuxMethod [_ _ _ _]
     (throw (UnsupportedOperationException. "Clojure-style multimethods do not support auxiliary methods.")))
 
-  (remove-aux-method [_ _ _ _]
+  (removeAuxMethod [_ _ _ _]
     (throw (UnsupportedOperationException. "Clojure-style multimethods do not support auxiliary methods."))))

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -1,9 +1,8 @@
 (ns methodical.impl.method-table.standard
-  (:require [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]])
+  (:require [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 
-(p.types/deftype+ StandardMethodTable [primary aux]
+(deftype StandardMethodTable [primary aux]
   PrettyPrintable
   (pretty [_]
     (cons

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -24,25 +24,25 @@
          (= aux (.aux ^StandardMethodTable another))))
 
   MethodTable
-  (primary-methods [_]
+  (primaryMethods [_]
     primary)
 
-  (aux-methods [_]
+  (auxMethods [_]
     aux)
 
-  (add-primary-method [this dispatch-val method]
+  (addPrimaryMethod [this dispatch-val method]
     (let [new-primary (assoc primary dispatch-val method)]
       (if (= primary new-primary)
         this
         (StandardMethodTable. new-primary aux))))
 
-  (remove-primary-method [this dispatch-val]
+  (removePrimaryMethod [this dispatch-val]
     (let [new-primary (dissoc primary dispatch-val)]
       (if (= primary new-primary)
         this
         (StandardMethodTable. new-primary aux))))
 
-  (add-aux-method [this qualifier dispatch-value method]
+  (addAuxMethod [this qualifier dispatch-value method]
     (let [new-aux (update-in aux [qualifier dispatch-value] (fn [existing-methods]
                                                               (if (contains? (set existing-methods) method)
                                                                 existing-methods
@@ -51,7 +51,7 @@
         this
         (StandardMethodTable. primary new-aux))))
 
-  (remove-aux-method [this qualifier dispatch-value method]
+  (removeAuxMethod [this qualifier dispatch-value method]
     (let [xforms  [(fn [aux]
                      (update-in aux [qualifier dispatch-value] (fn [defined-methods]
                                                                  (remove #(= % method) defined-methods))))

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -1,10 +1,9 @@
 (ns methodical.impl.multifn.cached
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Cache MultiFnImpl]))
 
-(p.types/deftype+ CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
+(deftype CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
   PrettyPrintable
   (pretty [_]
     (list 'cached-multifn-impl impl cache))

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -17,28 +17,28 @@
          (= (class cache) (class (.cache ^CachedMultiFnImpl another)))))
 
   MultiFnImpl
-  (method-combination [_]
+  (methodCombination [_]
     (i/method-combination impl))
 
   (dispatcher [_]
     (.dispatcher impl))
 
-  (with-dispatcher [this new-dispatcher]
+  (withDispatcher [this new-dispatcher]
     (let [new-impl (i/with-dispatcher impl new-dispatcher)]
       (if (= impl new-impl)
         this
         (CachedMultiFnImpl. new-impl (i/empty-copy cache)))))
 
-  (method-table [_]
+  (methodTable [_]
     (i/method-table impl))
 
-  (with-method-table [this new-method-table]
+  (withMethodTable [this new-method-table]
     (let [new-impl (i/with-method-table impl new-method-table)]
       (if (= impl new-impl)
         this
         (CachedMultiFnImpl. new-impl (i/empty-copy cache)))))
 
-  (effective-method [_ dispatch-value]
+  (effectiveMethod [_ dispatch-value]
     (or
      (.cached-method cache dispatch-value)
      (let [method (i/effective-method impl dispatch-value)]

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -40,7 +40,7 @@
 
   (effectiveMethod [_ dispatch-value]
     (or
-     (.cached-method cache dispatch-value)
+     (.cachedMethod cache dispatch-value)
      (let [method (i/effective-method impl dispatch-value)]
        (i/cache-method! cache dispatch-value method)
        method))))

--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -29,24 +29,24 @@
                 (= method-table (.method-table another))))))
 
   MultiFnImpl
-  (method-combination [_]
+  (methodCombination [_]
     combo)
 
   (dispatcher [_]
     dispatcher)
 
-  (with-dispatcher [this new-dispatcher]
+  (withDispatcher [this new-dispatcher]
     (if (= dispatcher new-dispatcher)
       this
       (StandardMultiFnImpl. combo new-dispatcher method-table)))
 
-  (method-table [_]
+  (methodTable [_]
     method-table)
 
-  (with-method-table [this new-method-table]
+  (withMethodTable [this new-method-table]
     (if (= method-table new-method-table)
       this
       (StandardMultiFnImpl. combo dispatcher new-method-table)))
 
-  (effective-method [_ dispatch-value]
+  (effectiveMethod [_ dispatch-value]
     (standard-effective-method combo dispatcher method-table dispatch-value)))

--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -1,7 +1,6 @@
 (ns methodical.impl.multifn.standard
   "Standard Methodical MultiFn impl, which "
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
@@ -13,9 +12,9 @@
         aux-methods     (i/matching-aux-methods dispatcher method-table dispatch-value)]
     (i/combine-methods method-combination primary-methods aux-methods)))
 
-(p.types/deftype+ StandardMultiFnImpl [^MethodCombination combo
-                                       ^Dispatcher dispatcher
-                                       ^MethodTable method-table]
+(deftype StandardMultiFnImpl [^MethodCombination combo
+                              ^Dispatcher dispatcher
+                              ^MethodTable method-table]
   PrettyPrintable
   (pretty [_]
     (list 'standard-multifn-impl combo dispatcher method-table))

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -50,13 +50,13 @@
       (StandardMultiFn. impl new-meta)))
 
   MethodCombination
-  (allowed-qualifiers [_]
+  (allowedQualifiers [_]
     (i/allowed-qualifiers (i/method-combination impl)))
 
-  (combine-methods [_ primary-methods aux-methods]
+  (combineMethods [_ primary-methods aux-methods]
     (i/combine-methods (i/method-combination impl) primary-methods aux-methods))
 
-  (transform-fn-tail [_ qualifier fn-tail]
+  (transformFnTail [_ qualifier fn-tail]
     (i/transform-fn-tail (i/method-combination impl) qualifier fn-tail))
 
   Dispatcher

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -10,22 +10,22 @@
 
 (defn- ^:static invoke-multifn
   ([^MultiFnImpl impl]
-   ((effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl)))))
+   ((effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl)))))
 
   ([^MultiFnImpl impl a]
-   ((effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a)) a))
+   ((effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a)) a))
 
   ([^MultiFnImpl impl a b]
-   ((effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b)) a b))
+   ((effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a b)) a b))
 
   ([^MultiFnImpl impl a b c]
-   ((effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c)) a b c))
+   ((effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a b c)) a b c))
 
   ([^MultiFnImpl impl a b c d]
-   ((effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d)) a b c d))
+   ((effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a b c d)) a b c d))
 
   ([^MultiFnImpl impl a b c d & more]
-   (apply (effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d more)) a b c d more)))
+   (apply (effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a b c d more)) a b c d more)))
 
 (p.types/deftype+ StandardMultiFn [^MultiFnImpl impl mta]
   PrettyPrintable
@@ -60,51 +60,51 @@
     (i/transform-fn-tail (i/method-combination impl) qualifier fn-tail))
 
   Dispatcher
-  (dispatch-value [_]
-    (.dispatch-value ^Dispatcher (.dispatcher impl)))
-  (dispatch-value [_ a]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a))
-  (dispatch-value [_ a b]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a b))
-  (dispatch-value [_ a b c]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c))
-  (dispatch-value [_ a b c d]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d))
-  (dispatch-value [_ a b c d more]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d more))
+  (dispatchValue [_]
+    (.dispatchValue ^Dispatcher (.dispatcher impl)))
+  (dispatchValue [_ a]
+    (.dispatchValue ^Dispatcher (.dispatcher impl) a))
+  (dispatchValue [_ a b]
+    (.dispatchValue ^Dispatcher (.dispatcher impl) a b))
+  (dispatchValue [_ a b c]
+    (.dispatchValue ^Dispatcher (.dispatcher impl) a b c))
+  (dispatchValue [_ a b c d]
+    (.dispatchValue ^Dispatcher (.dispatcher impl) a b c d))
+  (dispatchValue [_ a b c d more]
+    (.dispatchValue ^Dispatcher (.dispatcher impl) a b c d more))
 
-  (matching-primary-methods [_ method-table dispatch-value]
+  (matchingPrimaryMethods [_ method-table dispatch-value]
     (i/matching-primary-methods (.dispatcher impl) method-table dispatch-value))
 
-  (matching-aux-methods [_ method-table dispatch-value]
+  (matchingAuxMethods [_ method-table dispatch-value]
     (i/matching-aux-methods (.dispatcher impl) method-table dispatch-value))
 
-  (default-dispatch-value [_]
+  (defaultDispatchValue [_]
     (i/default-dispatch-value (.dispatcher impl)))
 
   (prefers [_]
     (i/prefers (.dispatcher impl)))
 
-  (prefer-method [this dispatch-val-x dispatch-val-y]
+  (preferMethod [this dispatch-val-x dispatch-val-y]
     (i/with-dispatcher this (i/prefer-method (.dispatcher impl) dispatch-val-x dispatch-val-y)))
 
   MethodTable
-  (primary-methods [_]
+  (primaryMethods [_]
     (i/primary-methods (i/method-table impl)))
 
-  (aux-methods [_]
+  (auxMethods [_]
     (i/aux-methods (i/method-table impl)))
 
-  (add-primary-method [this dispatch-val method]
+  (addPrimaryMethod [this dispatch-val method]
     (i/with-method-table this (i/add-primary-method (i/method-table impl) dispatch-val method)))
 
-  (remove-primary-method [this dispatch-val]
+  (removePrimaryMethod [this dispatch-val]
     (i/with-method-table this (i/remove-primary-method (i/method-table impl) dispatch-val)))
 
-  (add-aux-method [this qualifier dispatch-val method]
+  (addAuxMethod [this qualifier dispatch-val method]
     (i/with-method-table this (i/add-aux-method (i/method-table impl) qualifier dispatch-val method)))
 
-  (remove-aux-method [this qualifier dispatch-val method]
+  (removeAuxMethod [this qualifier dispatch-val method]
     (i/with-method-table this (i/remove-aux-method (i/method-table impl) qualifier dispatch-val method)))
 
   MultiFnImpl

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -1,6 +1,5 @@
 (ns methodical.impl.standard
   (:require [methodical.interface :as i]
-            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
@@ -27,7 +26,7 @@
   ([^MultiFnImpl impl a b c d & more]
    (apply (effective-method impl (.dispatchValue ^Dispatcher (.dispatcher impl) a b c d more)) a b c d more)))
 
-(p.types/deftype+ StandardMultiFn [^MultiFnImpl impl mta]
+(deftype StandardMultiFn [^MultiFnImpl impl mta]
   PrettyPrintable
   (pretty [_]
     (list 'multifn impl))

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -5,7 +5,7 @@
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
 (defn- ^:static effective-method [^MultiFnImpl impl, dispatch-value]
-  (or (.effective-method impl dispatch-value)
+  (or (.effectiveMethod impl dispatch-value)
       (throw (UnsupportedOperationException. (format "No matching method for dispatch value %s" dispatch-value)))))
 
 (defn- ^:static invoke-multifn
@@ -108,29 +108,29 @@
     (i/with-method-table this (i/remove-aux-method (i/method-table impl) qualifier dispatch-val method)))
 
   MultiFnImpl
-  (method-combination [_]
+  (methodCombination [_]
     (i/method-combination impl))
 
   (dispatcher [_]
     (.dispatcher impl))
 
-  (with-dispatcher [this new-dispatcher]
+  (withDispatcher [this new-dispatcher]
     (assert (instance? Dispatcher new-dispatcher))
     (if (= (.dispatcher impl) new-dispatcher)
       this
       (StandardMultiFn. (i/with-dispatcher impl new-dispatcher) mta)))
 
-  (method-table [_]
+  (methodTable [_]
     (i/method-table impl))
 
-  (with-method-table [this new-method-table]
+  (withMethodTable [this new-method-table]
     (assert (instance? MethodTable new-method-table))
     (if (= (i/method-table impl) new-method-table)
       this
       (StandardMultiFn. (i/with-method-table impl new-method-table) mta)))
 
-  (effective-method [_ dispatch-value]
-    (.effective-method impl dispatch-value))
+  (effectiveMethod [_ dispatch-value]
+    (.effectiveMethod impl dispatch-value))
 
   java.util.concurrent.Callable
   (call [_]

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -169,15 +169,28 @@
   [^MultiFnImpl multifn dispatch-value]
   (.effectiveMethod multifn dispatch-value))
 
-(p.types/definterface+ Cache
-  (cached-method [cache dispatch-value]
-    "Return cached effective method for `dispatch-value`, if it exists in the cache.")
+(definterface Cache
+  (cachedMethod [dispatch-value])
+  (cacheMethodBang [dispatch-value method])
+  (clearCacheBang [])
+  (^methodical.interface.Cache emptyCopy []))
 
-  (cache-method! [cache dispatch-value method]
-    "Cache the effective method for `dispatch-value` in this cache.")
+(defn cached-method
+  "Return cached effective method for `dispatch-value`, if it exists in the cache."
+  [^Cache cache dispatch-value]
+  (.cachedMethod cache dispatch-value))
 
-  (clear-cache! [cache]
-    "Empty the contents of the cache in-place.")
+(defn cache-method!
+  "Cache the effective method for `dispatch-value` in this cache."
+  [^Cache cache dispatch-value method]
+  (.cacheMethodBang cache dispatch-value method))
 
-  (^methodical.interface.Cache empty-copy [cache]
-   "Return an empty copy of the same type as this cache, e.g. for use when copying a multifn."))
+(defn clear-cache!
+  "Empty the contents of the cache in-place."
+  [^Cache cache]
+  (.clearCacheBang cache))
+
+(defn ^methodical.interface.Cache empty-copy
+  "Return an empty copy of the same type as this cache, e.g. for use when copying a multifn."
+  [^Cache cache]
+  (.emptyCopy cache))

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -2,25 +2,35 @@
   (:refer-clojure :exclude [isa? prefers prefer-method])
   (:require [potemkin.types :as p.types]))
 
-(p.types/definterface+ MethodCombination
-  (allowed-qualifiers [method-combination]
-    "The set containg all qualifiers supported by this method combination. `nil` in the set means the method
+(definterface MethodCombination
+  (allowedQualifiers [])
+  (combineMethods [primary-methods aux-methods])
+  (transformFnTail [qualifier fn-tail]))
+
+(defn allowed-qualifiers
+  "The set containg all qualifiers supported by this method combination. `nil` in the set means the method
     combination supports primary methods (because primary methods have no qualifier); all other values refer to
     auxiliary methods with that qualifer, e.g. `:before`, `:after`, or `:around`.
 
     (allowed-qualifiers (clojure-method-combination)) ;-> #{nil}
     (allowed-qualifiers (clos-method-combination))    ;-> #{nil :before :after :around}
-    (allowed-qualifiers (doseq-method-combination))   ;-> #{:doseq}")
+    (allowed-qualifiers (doseq-method-combination))   ;-> #{:doseq}"
+  [^MethodCombination method-combination]
+  (.allowedQualifiers method-combination))
 
-  (combine-methods [method-combination primary-methods aux-methods]
-    "Combine a sequence of matching `primary-methods` with `aux-methods` (a map of qualifier -> sequence of methods)
-    into a single effective method.")
+(defn combine-methods
+  "Combine a sequence of matching `primary-methods` with `aux-methods` (a map of qualifier -> sequence of methods)
+    into a single effective method."
+  [^MethodCombination method-combination primary-methods aux-methods]
+  (.combineMethods method-combination primary-methods aux-methods))
 
-  (transform-fn-tail [method-combination qualifier fn-tail]
-    "Make appropriate transformations to the `fn-tail` of a `defmethod` macro expansion for a primary
+(defn transform-fn-tail
+  "Make appropriate transformations to the `fn-tail` of a `defmethod` macro expansion for a primary
     method (qualifier will be `nil`) or an auxiliary method. You can use this method to add implicit args like
     `next-method` to the body of a `defmethod` macro. (Because this method is invoked during macroexpansion, it should
-    return a Clojure form.)"))
+    return a Clojure form.)"
+  [^MethodCombination method-combination qualifier fn-tail]
+  (.transformFnTail method-combination qualifier fn-tail))
 
 (p.types/definterface+ MethodTable
   (primary-methods [method-table]

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -1,6 +1,5 @@
 (ns methodical.interface
-  (:refer-clojure :exclude [isa? prefers prefer-method])
-  (:require [potemkin.types :as p.types]))
+  (:refer-clojure :exclude [isa? prefers prefer-method]))
 
 (definterface MethodCombination
   (allowedQualifiers [])

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -1,8 +1,8 @@
 (ns methodical.interface
   (:refer-clojure :exclude [isa? prefers prefer-method]))
 
-(defmacro ^:private defonceinterface [name & body]
-  (let [class-name (clojure.string/replace (str *ns* "." name) #"\-" "_")
+(defmacro ^:private defonceinterface [interface-name & body]
+  (let [class-name (clojure.string/replace (str *ns* "." interface-name) #"\-" "_")
         exists     (try
                      (Class/forName class-name)
                      true
@@ -12,7 +12,7 @@
       `(do
          (import ~(symbol class-name))
          nil)
-      `(definterface ~name ~@body))))
+      `(definterface ~interface-name ~@body))))
 
 (defonceinterface MethodCombination
   (allowedQualifiers [])

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -128,27 +128,46 @@
   [^Dispatcher dispatcher dispatch-val-x dispatch-val-y]
   (.preferMethod dispatcher dispatch-val-x dispatch-val-y))
 
-(p.types/definterface+ MultiFnImpl
-  (^methodical.interface.MethodCombination method-combination [multifn]
-   "Get the method combination associated with this multifn.")
+(definterface MultiFnImpl
+  (^methodical.interface.MethodCombination methodCombination [])
+  (^methodical.interface.Dispatcher dispatcher [])
+  (^methodical.interface.MultiFnImpl withDispatcher [new-dispatcher])
+  (^methodical.interface.MethodTable methodTable [])
+  (^methodical.interface.MultiFnImpl withMethodTable [new-method-table])
+  (effectiveMethod [dispatch-value]))
 
-  (^methodical.interface.Dispatcher dispatcher [multifn]
-   "Get the dispatcher associated with this multifn.")
+(defn ^methodical.interface.MethodCombination method-combination
+  "Get the method combination associated with this multifn."
+  [^MultiFnImpl multifn]
+  (.methodCombination multifn))
 
-  (^methodical.interface.MultiFnImpl with-dispatcher [multifn new-dispatcher]
-   "Return a copy of this multifn using `new-dispatcher` as its dispatcher.")
+(defn ^methodical.interface.Dispatcher dispatcher
+  "Get the dispatcher associated with this multifn."
+  [^MultiFnImpl multifn]
+  (.dispatcher multifn))
 
-  (^methodical.interface.MethodTable method-table [multifn]
-   "Get the method table associated with this multifn.")
+(defn ^methodical.interface.MultiFnImpl with-dispatcher
+  "Return a copy of this multifn using `new-dispatcher` as its dispatcher."
+  [^MultiFnImpl multifn new-dispatcher]
+  (.withDispatcher multifn new-dispatcher))
 
-  (^methodical.interface.MultiFnImpl with-method-table [multifn new-method-table]
-   "Return a copy of this multifn using `new-method-table` as its method table.")
+(defn ^methodical.interface.MethodTable method-table
+  "Get the method table associated with this multifn."
+  [^MultiFnImpl multifn]
+  (.methodTable multifn))
 
-  (effective-method [multifn dispatch-value]
-    "Return the effective method for `dispatch-value`. The effective method is a combined primary method and
+(defn ^methodical.interface.MultiFnImpl with-method-table
+  "Return a copy of this multifn using `new-method-table` as its method table."
+  [^MultiFnImpl multifn new-method-table]
+  (.withMethodTable multifn new-method-table))
+
+(defn effective-method
+  "Return the effective method for `dispatch-value`. The effective method is a combined primary method and
     applicable auxiliary methods that can be called like a normal function. `effective-method` is similar in purpose
     to `get-method` in vanilla Clojure multimethods; a different name is used here because I felt `get-method` would
-    be ambiguous with regards to whether it returns only a primary method or a combined effective method."))
+    be ambiguous with regards to whether it returns only a primary method or a combined effective method."
+  [^MultiFnImpl multifn dispatch-value]
+  (.effectiveMethod multifn dispatch-value))
 
 (p.types/definterface+ Cache
   (cached-method [cache dispatch-value]

--- a/src/methodical/interface.cljc
+++ b/src/methodical/interface.cljc
@@ -1,23 +1,27 @@
 (ns methodical.interface
   (:refer-clojure :exclude [isa? prefers prefer-method]))
 
-(defmacro ^:private defonceinterface [interface-name & body]
-  (let [class-name (clojure.string/replace (str *ns* "." interface-name) #"\-" "_")
-        exists     (try
-                     (Class/forName class-name)
-                     true
-                     (catch Exception _
-                       false))]
-    (if exists
-      `(do
-         (import ~(symbol class-name))
-         nil)
-      `(definterface ~interface-name ~@body))))
+#?(:clj
+   (defmacro ^:private defonceinterface [interface-name & body]
+     (let [class-name (clojure.string/replace (str *ns* "." interface-name) #"\-" "_")
+           exists     (try
+                        (Class/forName class-name)
+                        true
+                        (catch Exception _
+                          false))]
+       (if exists
+         `(do
+            (import ~(symbol class-name))
+            nil)
+         `(definterface ~interface-name ~@body)))))
 
-(defonceinterface MethodCombination
-  (allowedQualifiers [])
-  (combineMethods [primary-methods aux-methods])
-  (transformFnTail [qualifier fn-tail]))
+#?(:clj
+   (defonceinterface MethodCombination
+     (allowedQualifiers [])
+     (combineMethods [primary-methods aux-methods])
+     (transformFnTail [qualifier fn-tail]))
+   :cljs
+   (def MethodCombination))
 
 (defn allowed-qualifiers
   "The set containg all qualifiers supported by this method combination. `nil` in the set means the method
@@ -44,13 +48,16 @@
   [^MethodCombination method-combination qualifier fn-tail]
   (.transformFnTail method-combination qualifier fn-tail))
 
-(defonceinterface MethodTable
-  (primaryMethods [])
-  (auxMethods [])
-  (addPrimaryMethod [dispatch-value f])
-  (removePrimaryMethod [dispatch-value])
-  (addAuxMethod [qualifier dispatch-value f])
-  (removeAuxMethod [qualifier dispatch-val method]))
+#?(:clj
+   (defonceinterface MethodTable
+     (primaryMethods [])
+     (auxMethods [])
+     (addPrimaryMethod [dispatch-value f])
+     (removePrimaryMethod [dispatch-value])
+     (addAuxMethod [qualifier dispatch-value f])
+     (removeAuxMethod [qualifier dispatch-val method]))
+   :cljs
+   (def MethodTable))
 
 (defn primary-methods
   "Get a `dispatch-value -> fn` map of all primary methods assoicated with this method table."
@@ -88,19 +95,22 @@
   [^MethodTable method-table qualifier dispatch-val method]
   (.removeAuxMethod method-table qualifier dispatch-val method))
 
-(defonceinterface Dispatcher
-  (dispatchValue [])
-  (dispatchValue [a])
-  (dispatchValue [a b])
-  (dispatchValue [a b c])
-  (dispatchValue [a b c d])
-  (dispatchValue [a b c d more])
+#?(:clj
+   (defonceinterface Dispatcher
+     (dispatchValue [])
+     (dispatchValue [a])
+     (dispatchValue [a b])
+     (dispatchValue [a b c])
+     (dispatchValue [a b c d])
+     (dispatchValue [a b c d more])
 
-  (matchingPrimaryMethods [method-table dispatch-value])
-  (matchingAuxMethods [method-table dispatch-value])
-  (defaultDispatchValue [])
-  (prefers [])
-  (preferMethod [dispatch-val-x dispatch-val-y]))
+     (matchingPrimaryMethods [method-table dispatch-value])
+     (matchingAuxMethods [method-table dispatch-value])
+     (defaultDispatchValue [])
+     (prefers [])
+     (preferMethod [dispatch-val-x dispatch-val-y]))
+   :cljs
+   (def Dispatcher))
 
 (defn dispatch-value
   "Return an appropriate dispatch value for args passed to a multimethod. (This method is equivalent in purpose to
@@ -140,13 +150,16 @@
   [^Dispatcher dispatcher dispatch-val-x dispatch-val-y]
   (.preferMethod dispatcher dispatch-val-x dispatch-val-y))
 
-(defonceinterface MultiFnImpl
-  (^methodical.interface.MethodCombination methodCombination [])
-  (^methodical.interface.Dispatcher dispatcher [])
-  (^methodical.interface.MultiFnImpl withDispatcher [new-dispatcher])
-  (^methodical.interface.MethodTable methodTable [])
-  (^methodical.interface.MultiFnImpl withMethodTable [new-method-table])
-  (effectiveMethod [dispatch-value]))
+#?(:clj
+   (defonceinterface MultiFnImpl
+     (^methodical.interface.MethodCombination methodCombination [])
+     (^methodical.interface.Dispatcher dispatcher [])
+     (^methodical.interface.MultiFnImpl withDispatcher [new-dispatcher])
+     (^methodical.interface.MethodTable methodTable [])
+     (^methodical.interface.MultiFnImpl withMethodTable [new-method-table])
+     (effectiveMethod [dispatch-value]))
+   :cljs
+   (def MultiFnImpl))
 
 (defn ^methodical.interface.MethodCombination method-combination
   "Get the method combination associated with this multifn."
@@ -181,11 +194,14 @@
   [^MultiFnImpl multifn dispatch-value]
   (.effectiveMethod multifn dispatch-value))
 
-(defonceinterface Cache
-  (cachedMethod [dispatch-value])
-  (cacheMethodBang [dispatch-value method])
-  (clearCacheBang [])
-  (^methodical.interface.Cache emptyCopy []))
+#?(:clj
+   (defonceinterface Cache
+     (cachedMethod [dispatch-value])
+     (cacheMethodBang [dispatch-value method])
+     (clearCacheBang [])
+     (^methodical.interface.Cache emptyCopy []))
+   :cljs
+   (def Cache))
 
 (defn cached-method
   "Return cached effective method for `dispatch-value`, if it exists in the cache."

--- a/test/methodical/impl/cache/watching_test.clj
+++ b/test/methodical/impl/cache/watching_test.clj
@@ -9,7 +9,7 @@
   [& [num-times-cleared]]
   (reify
     Cache
-    (clear-cache! [_]
+    (clearCacheBang [_]
       (some-> num-times-cleared (swap! inc)))
 
     PrettyPrintable

--- a/test/methodical/impl/dispatcher/standard_test.clj
+++ b/test/methodical/impl/dispatcher/standard_test.clj
@@ -15,8 +15,8 @@
 
 (defn- method-table [primary-methods aux-methods]
   (reify MethodTable
-    (primary-methods [_] primary-methods)
-    (aux-methods [_] aux-methods)))
+    (primaryMethods [_] primary-methods)
+    (auxMethods [_] aux-methods)))
 
 (def ^:private basic-hierarchy
   (-> (make-hierarchy)


### PR DESCRIPTION
I replaced `definterface+` with `definterface` for further clojurescript support  #20.  
UPD: Also I replaced `deftype+` with `deftype`.

Helper functions are not inlined like potemkin do because I not see any performance impact.

So we can do it:
```clojure
#?(:clj
   (definterface Foo
     (fooBar []))
   :cljs
   (def Foo))

;; helper function
(defn foo-bar [^Foo foo]
  (.fooBar foo))

(deftype Bar []
  #?(:clj Foo
     :cljs Object)
  (fooBar [_] :ok))

(foo-bar (Bar.))
```