### PR TITLE
Disable AOT so deps aren't compiled into JAR

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,8 +28,6 @@
   [[pretty "1.0.4"]
    [potemkin "0.4.5"]]
 
-  :aot [methodical.interface methodical.impl.standard]
-
   :jvm-opts ["-Dclojure.compiler.direct-linking=true"]
 
   :profiles
@@ -110,7 +108,8 @@
    {:plugins               [[lein-check-namespace-decls "1.0.2"
                              :exclusions [org.clojure/clojure]]]
     :source-paths          ["test"]
-    :check-namespace-decls {:prefix-rewriting true}}
+    :check-namespace-decls {:prefix-rewriting true
+                            :prune-ns-form    false}}
 
    :docstring-checker
    {:plugins

--- a/src/methodical/impl.clj
+++ b/src/methodical/impl.clj
@@ -18,7 +18,8 @@
             [methodical.impl.multifn
              [cached :as multifn.cached]
              [standard :as multifn.standard]]
-            [methodical.impl.standard :as impl.standard])
+            [methodical.impl.standard :as impl.standard]
+            methodical.interface)
   (:import methodical.impl.standard.StandardMultiFn
            [methodical.interface Cache Dispatcher MethodCombination MethodTable MultiFnImpl]))
 

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -2,7 +2,8 @@
   "A basic, dumb cache. `SimpleCache` stores cached methods in a simple map of dispatch-value -> effective method; it
   offers no facilities to deduplicate identical methods for the same dispatch value. This behaves similarly to the
   caching mechanism in vanilla Clojure."
-  (:require [potemkin.types :as p.types]
+  (:require methodical.interface
+            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.Cache))
 

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -1,7 +1,8 @@
 (ns methodical.impl.combo.clojure
   "Simple method combination strategy that mimics the way vanilla Clojure multimethods combine methods; that is, to say,
   not at all. Like vanilla Clojure multimethods, this method combination only supports primary methods."
-  (:require [potemkin.types :as p.types]
+  (:require methodical.interface
+            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))
 

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -4,6 +4,7 @@
   are ignored. Primary methods and around methods get an implicit `next-method` arg (see Methodical dox for more on
   what this means)."
   (:require [methodical.impl.combo.common :as combo.common]
+            methodical.interface
             [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -38,6 +38,7 @@
       ...)"
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
+            methodical.interface
             [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -1,6 +1,7 @@
 (ns methodical.impl.combo.threaded
   (:refer-clojure :exclude [methods])
   (:require [methodical.impl.combo.common :as combo.common]
+            methodical.interface
             [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodCombination))

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -1,5 +1,6 @@
 (ns methodical.impl.method-table.clojure
-  (:require [potemkin.types :as p.types]
+  (:require methodical.interface
+            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -1,5 +1,6 @@
 (ns methodical.impl.method-table.standard
-  (:require [potemkin.types :as p.types]
+  (:require methodical.interface
+            [potemkin.types :as p.types]
             [pretty.core :refer [PrettyPrintable]])
   (:import methodical.interface.MethodTable))
 

--- a/test/methodical/impl/dispatcher/multi_default_test.clj
+++ b/test/methodical/impl/dispatcher/multi_default_test.clj
@@ -1,6 +1,6 @@
 (ns methodical.impl.dispatcher.multi-default-test
   (:require [clojure.test :as t]
-            [methodical.core :as m]
+            [methodical [core :as m] interface]
             [methodical.impl.dispatcher.multi-default :as multi-default])
   (:import methodical.interface.MethodTable))
 


### PR DESCRIPTION
Currently, `methodical.interface` and `methodical.impl.standard` are marked as AOT. This leads to potemkin and its dependencies being compiled into the deployed JAR, which can cause opaque dependency issues in consuming projects. By explicitly `:require`ing `methodical.interface` before `import`ing any of the generated Java interfaces, AOT compiling these namespaces can be avoided.

Resolves #33. Resolves #40.

---

Notes for @camsaul:
- No tests or docs needed updating.
- I updated the configuration for `check-namespace-decls` because `methodical.interface` needs to be required for side effects.

---

Thanks for contributing to Methodical. Before open a pull request, please take a moment to:

- [x] Ensure the PR follows the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide).
- [x] Tests and linters pass. You can run them locally as follows:

      lein test && lein lint

    CircleCI will also run these same tests against your PR.
- [ ] Make sure you've included new tests for any new features or bugfixes.
- [ ] New features are documented, or documentation is updated appropriately for any changed features.
- [x] Carefully review your own changes and revert any superfluous ones. (A good example would be moving words in the
      Markdown documentation to different lines in a way that wouldn't change how the rendered page itself would
      appear. These sorts of changes make a PR bigger than it needs to be, and, thus, harder to review.)

    Of course, indentation and typo fixes are not covered by this rule and are always appreciated.
- [x] Include a detailed explanation of what changes you're making and why you've made them. This will help me
      understand what's going on while we review it.

Once you've done all that, open a PR! Make sure to at-mention @camsaul in the PR description. Otherwise I won't get an
email about it and might not get review it right away. :)

Thanks for your contribution!
