### PR TITLE
Metadata should record ^:dispatch-value; have effective-primary-method return it

### DIFF
--- a/src/methodical/impl/dispatcher/multi_default.clj
+++ b/src/methodical/impl/dispatcher/multi_default.clj
@@ -98,8 +98,7 @@
                                 (unambiguous-pairs-seq-fn opts standard-pairs)
                                 partial-default-pairs
                                 (when default-pair [default-pair]))]
-    (for [[dispatch-value method] (dispatcher.common/distinct-by first pairs)]
-      (vary-meta method assoc :dispatch-value dispatch-value))))
+    (map second (dispatcher.common/distinct-by first pairs))))
 
 (defn- aux-dispatch-values [qualifier {:keys [default-value method-table dispatch-value hierarchy prefs]}]
   (let [comparitor (dispatcher.common/domination-comparitor hierarchy prefs dispatch-value)]
@@ -119,7 +118,7 @@
   (let [method-map (i/aux-methods method-table)]
     (for [dispatch-value (aux-dispatch-values qualifier opts)
           m              (get-in method-map [qualifier dispatch-value])]
-      (vary-meta m assoc :dispatch-value dispatch-value))))
+      m)))
 
 (defn matching-aux-methods
   "Impl of `Dispatcher` `matching-aux-methods` for the multi-default dispatcher."

--- a/src/methodical/impl/method_table/standard.clj
+++ b/src/methodical/impl/method_table/standard.clj
@@ -32,7 +32,7 @@
     aux)
 
   (add-primary-method [this dispatch-val method]
-    (let [new-primary (assoc primary dispatch-val method)]
+    (let [new-primary (assoc primary dispatch-val (vary-meta method assoc :dispatch-value dispatch-val))]
       (if (= primary new-primary)
         this
         (StandardMethodTable. new-primary aux))))
@@ -44,10 +44,13 @@
         (StandardMethodTable. new-primary aux))))
 
   (add-aux-method [this qualifier dispatch-value method]
-    (let [new-aux (update-in aux [qualifier dispatch-value] (fn [existing-methods]
-                                                              (if (contains? (set existing-methods) method)
-                                                                existing-methods
-                                                                (conj (vec existing-methods) method))))]
+    (let [new-aux (update-in aux
+                             [qualifier dispatch-value]
+                             (fn [existing-methods]
+                               (if (contains? (set existing-methods) method)
+                                 existing-methods
+                                 (conj (vec existing-methods)
+                                       (vary-meta method assoc :dispatch-value dispatch-value)))))]
       (if (= aux new-aux)
         this
         (StandardMethodTable. primary new-aux))))

--- a/src/methodical/util.clj
+++ b/src/methodical/util.clj
@@ -33,7 +33,8 @@
 
 (defn applicable-primary-method
   "Return the primary method that would be use for `dispatch-value`, including ones from ancestor dispatch values or the
-  default dipsatch value.
+  default dipsatch value. Method includes `^:dispatch-value` metadata indicating the actual dispatch value for which
+  the applicable method was defined.
 
   Like `primary-method`, the method returned will not have any implicit args (such as `next-method`) bound."
   [multifn dispatch-value]
@@ -44,7 +45,9 @@
   methods. Implicit args (such as `next-method`) will be bound appropriately. Method has `^:dispatch-value` metadata
   for the dispatch value with which the most-specific primary method was defined."
   [multifn dispatch-value]
-  (i/combine-methods multifn (matching-primary-methods multifn dispatch-value) nil))
+  (let [[most-specific-primary-method :as primary-methods] (matching-primary-methods multifn dispatch-value)]
+    (some-> (i/combine-methods multifn primary-methods nil)
+            (with-meta (meta most-specific-primary-method)))))
 
 (defn aux-methods
   "Get all auxiliary methods *explicitly specified* for `dispatch-value`. This function does not include methods that

--- a/test/methodical/impl/dispatcher/multi_default_test.clj
+++ b/test/methodical/impl/dispatcher/multi_default_test.clj
@@ -66,23 +66,24 @@
                                               nil       '[d]}
                                              {[default nil] '[dd d]}
                                              {[nil default] '[dd d]})
-          :let                              [table (reify MethodTable
-                                                     (primary-methods [_]
-                                                       {[:X :Y]           (with-meta 'XY {:dispatch-value [:X :Y]})
-                                                        [:X :y]           (with-meta 'Xy {:dispatch-value [:X :y]})
-                                                        [:x :Y]           (with-meta 'xY {:dispatch-value [:x :Y]})
-                                                        [:x :y]           (with-meta 'xy {:dispatch-value [:x :y]})
-                                                        [:X default]      (with-meta 'Xd {:dispatch-value [:X default]})
-                                                        [:x default]      (with-meta 'xd {:dispatch-value [:x default]})
-                                                        [default :Y]      (with-meta 'dY {:dispatch-value [default :Y]})
-                                                        [default :y]      (with-meta 'dy {:dispatch-value [default :y]})
-                                                        [default default] (with-meta 'dd {:dispatch-value [default default]})
-                                                        default           (with-meta 'd {:dispatch-value default})}))
-                                             h     (-> (make-hierarchy)
-                                                       (derive :X :x)
-                                                       (derive :Y :y)
-                                                       (derive :x :letter)
-                                                       (derive :y :letter))]]
+          :let
+          [table (reify MethodTable
+                   (primary-methods [_]
+                     {[:X :Y]           (with-meta 'XY {:dispatch-value [:X :Y]})
+                      [:X :y]           (with-meta 'Xy {:dispatch-value [:X :y]})
+                      [:x :Y]           (with-meta 'xY {:dispatch-value [:x :Y]})
+                      [:x :y]           (with-meta 'xy {:dispatch-value [:x :y]})
+                      [:X default]      (with-meta 'Xd {:dispatch-value [:X default]})
+                      [:x default]      (with-meta 'xd {:dispatch-value [:x default]})
+                      [default :Y]      (with-meta 'dY {:dispatch-value [default :Y]})
+                      [default :y]      (with-meta 'dy {:dispatch-value [default :y]})
+                      [default default] (with-meta 'dd {:dispatch-value [default default]})
+                      default           (with-meta 'd {:dispatch-value default})}))
+           h     (-> (make-hierarchy)
+                     (derive :X :x)
+                     (derive :Y :y)
+                     (derive :x :letter)
+                     (derive :y :letter))]]
     (t/testing (format "default value = %s dispatch value = %s" (pr-str default) (pr-str dispatch-value))
       (let [matching-methods (multi-default/matching-primary-methods
                               {:hierarchy                h

--- a/test/methodical/impl/dispatcher/multi_default_test.clj
+++ b/test/methodical/impl/dispatcher/multi_default_test.clj
@@ -68,16 +68,16 @@
                                              {[nil default] '[dd d]})
           :let                              [table (reify MethodTable
                                                      (primary-methods [_]
-                                                       {[:X :Y]           'XY
-                                                        [:X :y]           'Xy
-                                                        [:x :Y]           'xY
-                                                        [:x :y]           'xy
-                                                        [:X default]      'Xd
-                                                        [:x default]      'xd
-                                                        [default :Y]      'dY
-                                                        [default :y]      'dy
-                                                        [default default] 'dd
-                                                        default           'd}))
+                                                       {[:X :Y]           (with-meta 'XY {:dispatch-value [:X :Y]})
+                                                        [:X :y]           (with-meta 'Xy {:dispatch-value [:X :y]})
+                                                        [:x :Y]           (with-meta 'xY {:dispatch-value [:x :Y]})
+                                                        [:x :y]           (with-meta 'xy {:dispatch-value [:x :y]})
+                                                        [:X default]      (with-meta 'Xd {:dispatch-value [:X default]})
+                                                        [:x default]      (with-meta 'xd {:dispatch-value [:x default]})
+                                                        [default :Y]      (with-meta 'dY {:dispatch-value [default :Y]})
+                                                        [default :y]      (with-meta 'dy {:dispatch-value [default :y]})
+                                                        [default default] (with-meta 'dd {:dispatch-value [default default]})
+                                                        default           (with-meta 'd {:dispatch-value default})}))
                                              h     (-> (make-hierarchy)
                                                        (derive :X :x)
                                                        (derive :Y :y)
@@ -159,23 +159,25 @@
                                               nil       '[d]}
                                              {[default nil] '[dd d]}
                                              {[nil default] '[dd d]})
-          :let                              [table (reify MethodTable
-                                                     (aux-methods [_]
-                                                       {method-type {[:X :Y]           ['XY]
-                                                                     [:X :y]           ['Xy]
-                                                                     [:x :Y]           ['xY]
-                                                                     [:x :y]           ['xy]
-                                                                     [:X default]      ['Xd]
-                                                                     [:x default]      ['xd]
-                                                                     [default :Y]      ['dY]
-                                                                     [default :y]      ['dy]
-                                                                     [default default] ['dd]
-                                                                     default           ['d]}}))
-                                             h     (-> (make-hierarchy)
-                                                       (derive :X :x)
-                                                       (derive :Y :y)
-                                                       (derive :x :letter)
-                                                       (derive :y :letter))]]
+          :let
+          [table (reify MethodTable
+                   (aux-methods [_]
+                     {method-type {[:X :Y]           [(with-meta 'XY {:dispatch-value [:X :Y]})]
+                                   [:X :y]           [(with-meta 'Xy {:dispatch-value [:X :y]})]
+                                   [:x :Y]           [(with-meta 'xY {:dispatch-value [:x :Y]})]
+                                   [:x :y]           [(with-meta 'xy {:dispatch-value [:x :y]})]
+                                   [:X default]      [(with-meta 'Xd {:dispatch-value [:X default]})]
+                                   [:x default]      [(with-meta 'xd {:dispatch-value [:x default]})]
+                                   [default :Y]      [(with-meta 'dY {:dispatch-value [default :Y]})]
+                                   [default :y]      [(with-meta 'dy {:dispatch-value [default :y]})]
+                                   [default default] [(with-meta 'dd {:dispatch-value [default default]})]
+                                   default           [(with-meta 'd {:dispatch-value default})]}}))
+
+           h     (-> (make-hierarchy)
+                     (derive :X :x)
+                     (derive :Y :y)
+                     (derive :x :letter)
+                     (derive :y :letter))]]
     (t/testing (format "method-type = %s default value = %s dispatch value = %s"
                        method-type default (pr-str dispatch-value))
       (let [matching-methods (multi-default/matching-aux-methods

--- a/test/methodical/impl/method_table/standard_test.clj
+++ b/test/methodical/impl/method_table/standard_test.clj
@@ -1,6 +1,7 @@
 (ns methodical.impl.method-table.standard-test
   (:require [clojure.test :as t]
-            [methodical.impl.method-table.standard :refer [->StandardMethodTable]]))
+            [methodical.impl.method-table.standard :refer [->StandardMethodTable]]
+            [methodical.interface :as i]))
 
 (t/deftest print-test
   (t/is (= "(standard-method-table)"
@@ -22,3 +23,25 @@
   (t/is (= "(standard-method-table 2 :before)"
            (pr-str (->StandardMethodTable {} {:before {:b [+ +]}, :after {:a []}, :around {}})))
         "Method tables shouldn't print counts aux qualifiers that are empty."))
+
+(t/deftest add-dispatch-value-metadata-test
+  (t/testing "should add ^:dispatch-value metadata to methods when you add them"
+    (let [table (-> (->StandardMethodTable {} {})
+                    (i/add-primary-method [:x :y] 'f)
+                    (i/add-aux-method :before :x 'f))]
+      (t/testing "primary method"
+        (t/is (= {[:x :y] 'f}
+                 (i/primary-methods table)))
+        (let [method (-> (i/primary-methods table) vals first)]
+          (t/is (= 'f
+                   method))
+          (t/is (= {:dispatch-value [:x :y]}
+                   (meta method)))))
+      (t/testing "aux method"
+        (let [method (-> (i/aux-methods table) :before vals ffirst)]
+          (t/is (= {:before {:x ['f]}}
+                   (i/aux-methods table)))
+          (t/is (= 'f
+                   method))
+          (t/is (= {:dispatch-value :x}
+                   (meta method))))))))


### PR DESCRIPTION
- `standard-method-table` now adds `^:dispatch-value` metadata to methods when they're added to the table. This is used in a few different places to determine the effective dispatch value and the like
- `effective-primary-method` now returns `^:dispatch-value` metadata 
- 
Fixes #61