### PR TITLE
Fix trace, dispatch-fn etc with > 4 args

### DIFF
--- a/src/methodical/core.clj
+++ b/src/methodical/core.clj
@@ -39,7 +39,6 @@
   add-aux-method
   remove-aux-method
   ;; Dispatcher
-  dispatch-value
   default-dispatch-value
   prefers
   prefer-method
@@ -98,6 +97,7 @@
   default-aux-methods
   default-effective-method
   dispatch-fn
+  dispatch-value
   effective-dispatch-value
   remove-all-primary-methods
   remove-all-aux-methods

--- a/src/methodical/util.clj
+++ b/src/methodical/util.clj
@@ -103,10 +103,21 @@
   [multifn dispatch-value]
   (:dispatch-value (meta (i/effective-method multifn dispatch-value))))
 
+(defn dispatch-value
+  "Calculate the dispatch value that `multifn` will use given `args`."
+  ;; since protocols can't define varargs, we have to wrap the `dispatch-value` method from the protocol and apply
+  ;; varargs for > 4 args. The various < 4 args arities are there as an optimization because it's a little faster than
+  ;; calling apply every time.
+  ([multifn a]              (i/dispatch-value multifn a))
+  ([multifn a b]            (i/dispatch-value multifn a b))
+  ([multifn a b c]          (i/dispatch-value multifn a b c))
+  ([multifn a b c d]        (i/dispatch-value multifn a b c d))
+  ([multifn a b c d & more] (i/dispatch-value multifn a b c d more)))
+
 (defn dispatch-fn
   "Return a function that can be used to calculate dispatch values of given arg(s)."
   [multifn]
-  (partial i/dispatch-value multifn))
+  (partial dispatch-value multifn))
 
 (defn remove-all-primary-methods
   "Remove all primary methods, for all dispatch values (including the default value), for this `multifn` or method

--- a/src/methodical/util/trace.clj
+++ b/src/methodical/util/trace.clj
@@ -98,7 +98,7 @@
   "Function version of `trace` macro. The only difference is this doesn't capture the form of `multifn` passed to
   `trace`, and thus can't usually generate a pretty description for the top-level form."
   [multifn & args]
-  (let [dispatch-value  (apply i/dispatch-value multifn args)
+  (let [dispatch-value  (apply u/dispatch-value multifn args)
         primary-methods (trace-primary-methods (u/matching-primary-methods multifn dispatch-value))
         aux-methods     (trace-aux-methods (u/matching-aux-methods multifn dispatch-value))
         combined        (-> (i/combine-methods multifn primary-methods aux-methods)

--- a/test/methodical/util/trace_test.clj
+++ b/test/methodical/util/trace_test.clj
@@ -77,3 +77,28 @@
             "  1> {:bird? true, :object? true, :parrot? true, :type :parrot, :x 1}"
             "0> {:bird? true, :object? true, :parrot? true, :type :parrot, :x 1}"]
            (trace-output my-multimethod 1 {:type :parrot}))))
+
+(def ^:private lots-of-args-multifn
+  (-> (m/default-multifn
+       (fn [a b c d e f] [a (class b) c d e]))
+      (m/add-primary-method :default
+                            (fn [_ a _ _ _ _ f] {:a a, :f f}))
+      (m/add-primary-method [::x :default :default :default :default]
+                            (fn [_ a _ _ _ _ f] {:x a, :f f}))))
+
+(t/deftest lots-of-args-test
+  (t/testing "> 4 args"
+    (t/is (= {:x ::x, :f :f}
+             (lots-of-args-multifn ::x :b :c :d :e :f)))
+    (t/is (= ["0: (lots-of-args-multifn :methodical.util.trace-test/x :b :c :d :e :f)"
+              "  1: (#primary-method<[:methodical.util.trace-test/x :default :default :default :default]>"
+              "      #primary-method<:default>"
+              "      :methodical.util.trace-test/x"
+              "      :b"
+              "      :c"
+              "      :d"
+              "      :e"
+              "      :f)"
+              "  1> {:f :f, :x :methodical.util.trace-test/x}"
+              "0> {:f :f, :x :methodical.util.trace-test/x}"]
+             (trace-output lots-of-args-multifn ::x :b :c :d :e :f)))))

--- a/test/methodical/util_test.clj
+++ b/test/methodical/util_test.clj
@@ -139,6 +139,15 @@
     (let [f (m/default-multifn keyword)]
       (t/is (= :wow
                (u/dispatch-value f "wow"))))
+    (t/testing "2-4 args"
+      (let [f (-> (m/default-multifn vector)
+                  (m/add-primary-method :default (fn [& args] (vec args))))]
+        (t/is (= [:a]
+                 (u/dispatch-value f :a)))
+        (t/is (= [:a :b]
+                 (u/dispatch-value f :a :b)))
+        (t/is (= [:a :b :c]
+                 (u/dispatch-value f :a :b :c)))))
     (t/testing "> 4 args"
       (t/is [::x clojure.lang.Keyword :c :d :e]
             (u/dispatch-value lots-of-args-multifn ::x :b :c :d :e :f)))))

--- a/test/methodical/util_test.clj
+++ b/test/methodical/util_test.clj
@@ -147,7 +147,9 @@
         (t/is (= [:a :b]
                  (u/dispatch-value f :a :b)))
         (t/is (= [:a :b :c]
-                 (u/dispatch-value f :a :b :c)))))
+                 (u/dispatch-value f :a :b :c)))
+        (t/is (= [:a :b :c :d]
+                 (u/dispatch-value f :a :b :c :d)))))
     (t/testing "> 4 args"
       (t/is [::x clojure.lang.Keyword :c :d :e]
             (u/dispatch-value lots-of-args-multifn ::x :b :c :d :e :f)))))

--- a/test/methodical/util_test.clj
+++ b/test/methodical/util_test.clj
@@ -16,8 +16,7 @@
   (t/is (= true
            (u/multifn? (m/default-multifn keyword)))))
 
-(defn- test-multifn []
-  (let [m1 'm1
+(defn- test-multifn []  (let [m1 'm1
         m2 'm2]
     (-> (m/default-multifn class)
         (m/add-primary-method CharSequence m1)
@@ -121,6 +120,29 @@
       (t/is (= [:default]
                ((u/default-effective-method f) nil))))))
 
+(def ^:private lots-of-args-multifn
+  (-> (m/default-multifn
+       (fn [a b c d e f] [a (class b) c d e]))
+      (m/add-primary-method :default
+                            (fn [_ a _ _ _ _ f] {:a a, :f f}))
+      (m/add-primary-method [::x :default :default :default :default]
+                            (fn [_ a _ _ _ _ f] {:x a, :f f}))))
+
+(t/deftest lots-of-args-test
+  (t/is (= {:a :a, :f :f}
+           (lots-of-args-multifn :a :b :c :d :e :f)))
+  (t/is (= {:x ::x, :f :f}
+           (lots-of-args-multifn ::x :b :c :d :e :f))))
+
+(t/deftest dispatch-value-test
+  (t/testing "dispatch-value should return the dispatch value of arg(s)"
+    (let [f (m/default-multifn keyword)]
+      (t/is (= :wow
+               (u/dispatch-value f "wow"))))
+    (t/testing "> 4 args"
+      (t/is [::x clojure.lang.Keyword :c :d :e]
+            (u/dispatch-value lots-of-args-multifn ::x :b :c :d :e :f)))))
+
 (t/deftest effective-dispatch-value-test
   (doseq [default-method? [true false]]
     (t/testing (format "default method? %s" default-method?)
@@ -186,14 +208,20 @@
                (m/effective-dispatch-value f [:default nil])
                (m/effective-dispatch-value f [:default :default])
                (m/effective-dispatch-value f [:default ::shoe])
-               (m/effective-dispatch-value f [nil ::shoe]))))))
+               (m/effective-dispatch-value f [nil ::shoe])))))
+  (t/testing "> 4 args"
+    (t/is [::x :default :default :default :default]
+          (->> (u/dispatch-value lots-of-args-multifn ::x :b :c :d :e :f)
+               (u/effective-dispatch-value lots-of-args-multifn)))))
 
 (t/deftest dispatch-fn-test
-  (t/testing "dispatch-fn"
+  (t/testing "dispatch-fn should return a function that can be used to get the dispatch value of arg(s)"
     (let [f (m/default-multifn keyword)]
       (t/is (= :wow
-               ((u/dispatch-fn f) "wow"))
-            "dispatch-fn should return a function that can be used to get the dispatch value of arg(s)"))))
+               ((u/dispatch-fn f) "wow"))))
+    (t/testing "> 4 args"
+      (t/is [::x clojure.lang.Keyword :c :d :e]
+            ((u/dispatch-fn lots-of-args-multifn) ::x :b :c :d :e :f)))))
 
 (t/deftest primary-methods-test
   (let [m1 (constantly [:char-sequence])


### PR DESCRIPTION
Added new `u/dispatch-value` to use instead of calling `i/dispatch-value` (protocol method) directly. Protocols don't support varargs

Fixes #67