### PR TITLE
Minor `trace` tweaks

### DIFF
--- a/src/methodical/util/trace.clj
+++ b/src/methodical/util/trace.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [methodical.interface :as i]
             [methodical.util :as u]
+            [pretty.core :as pretty]
             [puget.printer :as puget]))
 
 (def ^:dynamic *color*
@@ -65,11 +66,12 @@
 
 (defn- describe [x]
   (cond
-    (::description (meta x))                (::description (meta x))
-    (:dispatch-value (meta x))              (describe-method x)
-    (:methodical/combined-method? (meta x)) (->Literal "#combined-method")
-    (fn? x)                                 (->Literal (pr-str x))
-    :else                                   x))
+    (::description (meta x))                  (::description (meta x))
+    (:dispatch-value (meta x))                (describe-method x)
+    (:methodical/combined-method? (meta x))   (->Literal "#combined-method")
+    (fn? x)                                   (->Literal (pr-str x))
+    (instance? pretty.core.PrettyPrintable x) (pretty/pretty x)
+    :else                                     x))
 
 (defn- trace-method [m]
   (fn [& args]
@@ -83,7 +85,7 @@
       (trace-print-indent)
       (printf "%d> " *trace-level*)
       (binding [*trace-indent* (+ *trace-indent* 3)]
-        (trace-println (with-out-str (pprint result))))
+        (trace-println (with-out-str (pprint (describe result)))))
       result)))
 
 (defn- trace-primary-method [primary-method]

--- a/test/methodical/util/trace_test.clj
+++ b/test/methodical/util/trace_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as str]
             [clojure.test :as t]
             [methodical.core :as m]
-            [methodical.util.trace :as trace]))
+            [methodical.util.trace :as trace]
+            [pretty.core :as pretty]))
 
 (def ^:private h
   (-> (make-hierarchy)
@@ -140,3 +141,25 @@
                   "  1> true"
                   "0> true"]
                  (trace-output my= int? 100)))))))
+
+(defrecord PrettyRecord [x]
+  pretty/PrettyPrintable
+  (pretty [_this]
+    (list '->PrettyRecord x)))
+
+(m/defmulti pretty-record
+  class)
+
+(m/defmethod pretty-record :default
+  [x]
+  x)
+
+(t/deftest pretty-print-PrettyPrintable-test
+  (t/testing "Use [[pretty.core/pretty]] to print things when possible"
+    (t/is (= "(->PrettyRecord {:a 1})"
+             (pr-str (pretty-record (->PrettyRecord {:a 1})))))
+    (t/is (= ["0: (pretty-record (->PrettyRecord {:a 1}))"
+              "  1: (#primary-method<:default> nil (->PrettyRecord {:a 1}))"
+              "  1> (->PrettyRecord {:a 1})"
+              "0> (->PrettyRecord {:a 1})"]
+             (trace-output pretty-record (->PrettyRecord {:a 1}))))))


### PR DESCRIPTION
- `trace` should use `pretty.core/pretty` to pretty-print `PrettyPrintable` things
- `trace` should use the same `description` method to print results as it uses to print args to method calls 