### PR TITLE
Consider all primary methods when calculating effective dispatch value

### DIFF
--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -73,16 +73,18 @@
             (range (count actual-dispatch-value))))))
 
 (defn effective-dispatch-value
-  "Given matching `primary-methods` and `aux-methods` for the actual `dispatch-value`, determine the effective dispatch
+  "Given matching `primary-methods` and `aux-methods` for the `actual-dispatch-value`, determine the effective dispatch
   value."
-  {:arglists '([dispatcher dispatch-value primary-methods aux-methods])}
-  [dispatcher dispatch-value [most-specific-primary-method] aux-methods]
+  [dispatcher actual-dispatch-value primary-methods aux-methods]
   (let [dispatch-values (transduce
-                         (comp cat (map meta) (map :dispatch-value) (filter some?))
+                         (comp cat
+                               (map meta)
+                               (map :dispatch-value)
+                               (filter some?))
                          conj
                          []
-                         (cons [most-specific-primary-method] (vals aux-methods)))]
-    (composite-effective-dispatch-value dispatcher dispatch-value dispatch-values)))
+                         (cons primary-methods (vals aux-methods)))]
+    (composite-effective-dispatch-value dispatcher actual-dispatch-value dispatch-values)))
 
 (defn standard-effective-method
   "Build an effective method using the 'standard' technique, taking the dispatch-value-method pairs in the


### PR DESCRIPTION
Consider this case:

- A `:toucan` isa `:can`
- A `:toucan` isa `:bird`
- We have a preference for `:bird` over `:can`
- We have a primary method for `:can`
- We have a primary method for `:bird`

If you invoke the multimethod with dispatch value `:bird`, it will use the `:bird` primary method with no `next-method`.

If you invoke the multimethod with dispatch value `:toucan`, it will use the `:bird` primary method with the `:can` primary method as the `next-method`.

Thus even though dispatch values `:bird` and `:toucan` both use the `:bird` primary method, their _effective dispatch values_ are not the same; because invoking the method with dispatch value `:bird` and with dispatch value `:toucan` is not the same thing.

We need to consider all matching dispatch values when calculating effective dispatch values.

This PR fixes the bug above