### PR TITLE
Macro parsing overhaul

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,7 +7,20 @@
   :unsorted-required-namespaces {:level :warning}
   :single-key-in                {:level :warning}
   :shadowed-var                 {:level :warning}
-  :unresolved-symbol            {}}
+  :unresolved-symbol            {}
+
+  :docstring-leading-trailing-whitespace {:level :warning}
+  :keyword-binding                       {:level :warning}
+  :misplaced-docstring                   {:level :warning}
+  :missing-body-in-when                  {:level :warning}
+  :missing-else-branch                   {:level :warning}
+  :namespace-name-mismatch               {:level :warning}
+  :non-arg-vec-return-type-hint          {:level :warning}
+  :reduce-without-init                   {:level :warning}
+  :redundant-fn-wrapper                  {:level :warning}
+  :use                                   {:level :warning}
+  :used-underscored-binding              {:level :warning}
+  :warn-on-reflection                    {:level :warning}}
 
  :lint-as
  {potemkin.types/deftype+ clojure.core/deftype}

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
       default:
         # Project must always have at least 80% coverage (by line)
         target: 85%
-        # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
+        # Whole-project test coverage is allowed to drop up to 5%. (For situations where we delete code with full coverage)
         threshold: 5%
     patch:
       default:

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,7 @@
+(ns user
+  (:require
+   [humane-are.core :as humane-are]
+   [pjstadig.humane-test-output :as humane-test-output]))
+
+(humane-test-output/activate!)
+(humane-are/install!)

--- a/resources/clj-kondo.exports/methodical/methodical/config.edn
+++ b/resources/clj-kondo.exports/methodical/methodical/config.edn
@@ -5,12 +5,10 @@
 
  :hooks
  {:analyze-call
-  {methodical.core/defmethod               hooks.methodical.core/defmethod
-   methodical.core/defmulti                hooks.methodical.core/defmulti
-   methodical.macros/define-aux-method     hooks.methodical.core/defmethod
-   methodical.macros/define-primary-method hooks.methodical.core/defmethod
-   methodical.macros/defmethod             hooks.methodical.core/defmethod
-   methodical.macros/defmulti              hooks.methodical.core/defmulti}
+  {methodical.core/defmethod   hooks.methodical.macros/defmethod
+   methodical.core/defmulti    hooks.methodical.macros/defmulti
+   methodical.macros/defmethod hooks.methodical.macros/defmethod
+   methodical.macros/defmulti  hooks.methodical.macros/defmulti}
 
   :macroexpand
   {methodical.impl.combo.operator/defoperator macros.methodical.impl.combo.operator/defoperator}}}

--- a/resources/clj-kondo.exports/methodical/methodical/hooks/methodical/macros.clj
+++ b/resources/clj-kondo.exports/methodical/methodical/hooks/methodical/macros.clj
@@ -1,0 +1,182 @@
+(ns hooks.methodical.macros
+  (:refer-clojure :exclude [defmulti defmethod])
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+;; (defn add-next-method [fn-tail]
+;;   (if (hooks/vector-node? (first fn-tail))
+;;     (let [[args & body] fn-tail]
+;;       (list*
+;;        (-> (hooks/vector-node
+;;             (cons (hooks/token-node 'next-method)
+;;                   (:children args)))
+;;            (with-meta (meta args)))
+;;        ;; so Kondo stops complaining about it being unused.
+;;        (hooks/token-node 'next-method)
+;;        body))
+;;     (for [list-node fn-tail]
+;;       (hooks/list-node (add-next-method (:children list-node))))))
+
+(defn- bindings-vector? [x]
+  (and (hooks/vector-node? x)
+       (every? (some-fn hooks/token-node?
+                        hooks/map-node?
+                        hooks/vector-node?)
+               (:children x))))
+
+(defn- single-arity-fn-tail? [args]
+  (bindings-vector? (first args)))
+
+(defn- n-arity-fn-tail? [args]
+  (and (seq args)
+       (every? (fn [x]
+                 (and (hooks/list-node? x)
+                      (single-arity-fn-tail? (:children x))))
+               args)))
+
+(defn- fn-tail? [args]
+  (or (single-arity-fn-tail? args)
+      (n-arity-fn-tail? args)))
+
+(defn- qualifier? [x]
+  (and (hooks/keyword-node? x)
+       (#{:before :after :around} (hooks/sexpr x))))
+
+(defn- dispatch-value?
+  "A dispatch value can be anything except for qualifier keyword or a list that looks like part of a n-arity function tail
+  e.g. `([x] x)`."
+  [x]
+  (and (not (qualifier? x))
+       (or (not (hooks/list-node? x))
+           (not (single-arity-fn-tail? (:children x))))))
+
+(defonce ^:private backtrack (Exception.))
+
+(defn- parse-defmethod-args
+  ([unparsed]
+   (let [parses (atom [])]
+     (try
+       (parse-defmethod-args parses {} unparsed)
+       (catch Exception _
+         (when (zero? (count @parses))
+           (throw (ex-info (format "Unable to parse defmethod args: %s" (pr-str (mapv hooks/sexpr unparsed)))
+                           {:args (mapv hooks/sexpr unparsed)})))
+         (when (> (count @parses) 1)
+           (throw (ex-info (format "Ambiguous defmethod args: %s" (pr-str (mapv hooks/sexpr unparsed)))
+                           {:args (mapv hooks/sexpr unparsed)
+                            :parses @parses})))
+         (first @parses)))))
+
+  ([parses parsed unparsed]
+   (cond
+     (and (not (contains? parsed :qualifier))
+          (qualifier? (first unparsed)))
+     (try
+       (parse-defmethod-args parses (assoc parsed :qualifier (first unparsed)) (rest unparsed))
+       (catch Exception _
+         (parse-defmethod-args parses (assoc parsed :qualifier nil) unparsed)))
+
+     (and (not (contains? parsed :dispatch-value))
+          (dispatch-value? (first unparsed)))
+     (parse-defmethod-args parses (assoc parsed :dispatch-value (first unparsed)) (rest unparsed))
+
+     (not (contains? parsed :dispatch-value))
+     (throw backtrack)
+
+     (and (not (contains? parsed :unique-key))
+          (:qualifier parsed)           ; can only have unique keys for aux methods
+          (not (hooks/string-node? (first unparsed)))
+          (not (hooks/list-node? (first unparsed)))
+          (not (hooks/vector-node? (first unparsed))))
+     (try
+       (parse-defmethod-args parses (assoc parsed :unique-key (first unparsed)) (rest unparsed))
+       (catch Exception _
+         (parse-defmethod-args parses (assoc parsed :unique-key nil) unparsed)))
+
+     (and (not (contains? parsed :docstring))
+          (hooks/string-node? (first unparsed)))
+     (try
+       (parse-defmethod-args parses (assoc parsed :docstring (first unparsed)) (rest unparsed))
+       (catch Exception _
+         (parse-defmethod-args parses (assoc parsed :docstring nil) unparsed)))
+
+     (fn-tail? unparsed)
+     (do
+       (swap! parses conj (assoc parsed :fn-tail unparsed))
+       (throw backtrack))
+
+     :else
+     (throw backtrack))))
+
+(defn defmethod
+  [{{[_ multimethod & args] :children, :as node} :node}]
+  (#_println)
+  #_(clojure.pprint/pprint (hooks/sexpr node))
+  (let [parsed (parse-defmethod-args args)]
+    #_(doseq [[k v] parsed]
+        (println \newline k '=> (pr-str (some-> v hooks/sexpr))))
+    (let [fn-tail     (:fn-tail parsed)
+          other-stuff (dissoc parsed :fn-tail)
+          result      (hooks/list-node
+                       (concat
+                        [(hooks/token-node 'do)
+                         multimethod]
+                        (filter some? (vals other-stuff))
+                        [(hooks/list-node
+                          (list*
+                           (hooks/token-node 'fn)
+                           (hooks/token-node 'next-method)
+                           fn-tail))]))]
+      #_(println "=>")
+      #_(clojure.pprint/pprint (hooks/sexpr result))
+      {:node result})))
+
+;;; this stuff is for debugging things to make sure we didn't do something dumb
+(comment
+  (defn defmethod* [form]
+    (hooks/sexpr (:node (defmethod {:node (hooks/parse-string (str form))}))))
+
+  (defmethod* '(defmethod mf :second [& _] 2))
+
+  (defmethod* '(m/defmethod multi-arity :k
+                 ([x]
+                  {:x x})
+                 ([x y]
+                  {:x x, :y y})))
+
+  (defmethod* '(m/defmethod mf1 :docstring
+                 "Docstring"
+                 [_x])))
+
+(defn defmulti
+  [{{[_ multimethod-name & args] :children, :as node} :node}]
+  #_(clojure.pprint/pprint (hooks/sexpr node))
+  (let [[docstring & args]         (if (hooks/string-node? (first args))
+                                     args
+                                     (cons nil args))
+        [attribute-map & args]     (if (hooks/map-node? (first args))
+                                     args
+                                     (cons nil args))
+        ;; if there wasn't a positional dispatch function arg passed just use (constantly nil) so Kondo won't complain
+        [dispatch-fn & kv-options] (if (odd? (count args))
+                                     args
+                                     (cons (hooks/list-node
+                                            (list
+                                             (hooks/token-node 'clojure.core/constantly)
+                                             (hooks/token-node 'nil)))
+                                           args))]
+    (let [defmulti-form (hooks/list-node
+                         (filter
+                          some?
+                          [(hooks/token-node 'clojure.core/defmulti)
+                           multimethod-name
+                           docstring
+                           attribute-map
+                           dispatch-fn]))
+          result   (hooks/list-node
+                    (list*
+                     (hooks/token-node 'do)
+                     defmulti-form
+                     kv-options))]
+      #_(println "=>")
+      #_(clojure.pprint/pprint (hooks/sexpr result))
+      {:node result})))

--- a/resources/clj-kondo.exports/methodical/methodical/hooks/methodical/macros.clj
+++ b/resources/clj-kondo.exports/methodical/methodical/hooks/methodical/macros.clj
@@ -2,19 +2,11 @@
   (:refer-clojure :exclude [defmulti defmethod])
   (:require [clj-kondo.hooks-api :as hooks]))
 
-;; (defn add-next-method [fn-tail]
-;;   (if (hooks/vector-node? (first fn-tail))
-;;     (let [[args & body] fn-tail]
-;;       (list*
-;;        (-> (hooks/vector-node
-;;             (cons (hooks/token-node 'next-method)
-;;                   (:children args)))
-;;            (with-meta (meta args)))
-;;        ;; so Kondo stops complaining about it being unused.
-;;        (hooks/token-node 'next-method)
-;;        body))
-;;     (for [list-node fn-tail]
-;;       (hooks/list-node (add-next-method (:children list-node))))))
+;;; The code below is basically simulating the spec for parsing defmethod args without using spec. It uses a basic
+;;; backtracking algorithm to achieve a similar result. Parsing defmethod args is kinda complicated.
+;;;
+;;; Unfortunately this is hardcoded to `:before`, `:after`, and `:around` as the only allowed qualifiers for now... at
+;;; some point in the future we'll have to figure out how to fix this and support other qualifiers too.
 
 (defn- bindings-vector? [x]
   (and (hooks/vector-node? x)

--- a/src/methodical/impl/cache/simple.clj
+++ b/src/methodical/impl/cache/simple.clj
@@ -7,6 +7,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.Cache))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (p.types/deftype+ SimpleCache [atomm]

--- a/src/methodical/impl/cache/watching.clj
+++ b/src/methodical/impl/cache/watching.clj
@@ -17,6 +17,8 @@
   (:import java.lang.ref.WeakReference
            methodical.interface.Cache))
 
+(set! *warn-on-reflection* true)
+
 (declare add-watches remove-watches)
 
 (p.types/deftype+ WatchingCache [^Cache cache watch-key refs]

--- a/src/methodical/impl/combo/clojure.clj
+++ b/src/methodical/impl/combo/clojure.clj
@@ -6,6 +6,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.MethodCombination))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (p.types/deftype+ ClojureMethodCombination []

--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -9,6 +9,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.MethodCombination))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 ;; TODO - I'm 90% sure we can leverage the `reducing-operator` stuff in `combo.operator` to implement this

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -6,6 +6,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.MethodCombination))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (defn reducer-fn
@@ -22,7 +24,7 @@
 (defn combine-with-threader
   "Combine primary and auxiliary methods using a threading invoker, i.e. something you'd get by calling
   `threading-invoker`. The way these methods are combined/reduced is the same, regardless of how args are threaded;
-  thus, various strategies such as `:thread-first` and `:thread-last` can both share the same `reducer-fn`. "
+  thus, various strategies such as `:thread-first` and `:thread-last` can both share the same `reducer-fn`."
   ([threader before-primary-afters]
    (comp (reducer-fn before-primary-afters) threader))
 

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -6,6 +6,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.Dispatcher))
 
+(set! *warn-on-reflection* true)
+
 (p.types/deftype+ EverythingDispatcher [hierarchy-var prefs]
   pretty/PrettyPrintable
   (pretty [_]

--- a/src/methodical/impl/dispatcher/multi_default.clj
+++ b/src/methodical/impl/dispatcher/multi_default.clj
@@ -9,6 +9,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.Dispatcher))
 
+(set! *warn-on-reflection* true)
+
 (defn- partially-specialized-default-dispatch-values* [dispatch-value default-value]
   ;; The basic idea here is to count down from (2^(count dispatch-value) - 2) to 0, then treat each bit as whether the
   ;; value at the corresponding position in `dispatch-value` should be included (if the bit is `1`) or if

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -8,6 +8,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.Dispatcher))
 
+(set! *warn-on-reflection* true)
+
 (defn matching-primary-pairs-excluding-default
   "Return a sequence of pairs of `[dispatch-value method]` for all applicable dispatch values, excluding the default
   method (if any); pairs are sorted in order from most-specific to least-specific."

--- a/src/methodical/impl/method_table/clojure.clj
+++ b/src/methodical/impl/method_table/clojure.clj
@@ -4,6 +4,8 @@
             [pretty.core :as pretty])
   (:import methodical.interface.MethodTable))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (p.types/deftype+ ClojureMethodTable [m]

--- a/src/methodical/impl/multifn/cached.clj
+++ b/src/methodical/impl/multifn/cached.clj
@@ -5,6 +5,8 @@
   (:import clojure.lang.Named
            [methodical.interface Cache MultiFnImpl]))
 
+(set! *warn-on-reflection* true)
+
 (p.types/deftype+ CachedMultiFnImpl [^MultiFnImpl impl, ^Cache cache]
   pretty/PrettyPrintable
   (pretty [_]

--- a/src/methodical/impl/multifn/standard.clj
+++ b/src/methodical/impl/multifn/standard.clj
@@ -6,6 +6,8 @@
             [pretty.core :as pretty])
   (:import [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
+(set! *warn-on-reflection* true)
+
 ;; "composite dispatch value" below just means a dispatch value consisting of multiple parts e.g. `[:x :y]` as opposed
 ;; to a single value like `:x`.
 

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -5,6 +5,8 @@
   (:import clojure.lang.Named
            [methodical.interface Dispatcher MethodCombination MethodTable MultiFnImpl]))
 
+(set! *warn-on-reflection* true)
+
 (defn- maybe-name [^MultiFnImpl impl]
   (if-let [nm (and (instance? Named impl) (name impl))]
     (str " " nm)

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -2,6 +2,8 @@
   (:refer-clojure :exclude [isa? prefers])
   (:require clojure.core))
 
+(set! *warn-on-reflection* true)
+
 ;; this is a dummy dependency until Cloverage 1.3.0 is released -- see
 ;; https://github.com/cloverage/cloverage/issues/318
 (comment clojure.core/keep-me)
@@ -48,7 +50,7 @@
   (add-aux-method ^methodical.interface.MethodTable [method-table qualifier dispatch-value f]
     "Add an auxiliary method implementation for `qualifier` (e.g. `:before`) and `dispatch-value`. Unlike primary
     methods, auxiliary methods are not limited to one method per dispatch value; thus this method does not remove
-    existing methods for this dispatch value. existing ")
+    existing methods for this dispatch value.")
 
   (remove-aux-method ^methodical.interface.MethodTable [method-table qualifier dispatch-val method]
     "Remove an auxiliary method from a method table. Because multiple auxiliary methods are allowed for the same

--- a/src/methodical/util.clj
+++ b/src/methodical/util.clj
@@ -5,6 +5,8 @@
   (:require [methodical.impl.standard :as impl.standard]
             [methodical.interface :as i]))
 
+(set! *warn-on-reflection* true)
+
 (defn multifn?
   "True if `x` is a Methodical multifn (i.e., if it is an instance of `StandardMultiFn`)."
   [x]
@@ -124,15 +126,14 @@
   table."
   [multifn]
   (reduce
-   (fn [multifn dispatch-val]
-     (i/remove-primary-method multifn dispatch-val))
+   i/remove-primary-method
    multifn
    (keys (i/primary-methods multifn))))
 
 (defn remove-all-aux-methods
   "With one arg, remove *all* auxiliary methods for a `multifn`. With two args, remove all auxiliary methods for the
   given `qualifier` (e.g. `:before`). With three args, remove all auxiliary methods for a given `qualifier` and
-  `dispatch-value`. "
+  `dispatch-value`."
   ([multifn]
    (reduce remove-all-aux-methods multifn (keys (i/aux-methods multifn))))
 

--- a/src/methodical/util/trace.clj
+++ b/src/methodical/util/trace.clj
@@ -5,6 +5,8 @@
             [pretty.core :as pretty]
             [puget.printer :as puget]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:dynamic *color*
   "Whether or not to print the trace in color. True by default, unless the env var `NO_COLOR` is true."
   (if-let [env-var-value (System/getenv "NO_COLOR")]

--- a/test/methodical/impl/cache/watching_test.clj
+++ b/test/methodical/impl/cache/watching_test.clj
@@ -6,6 +6,8 @@
   (:import methodical.impl.cache.watching.WatchingCache
            methodical.interface.Cache))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (defn- cache

--- a/test/methodical/impl/combo/clojure_test.clj
+++ b/test/methodical/impl/combo/clojure_test.clj
@@ -13,7 +13,8 @@
           [(constantly :a)] {:before [(constantly :b)]}))
         "Clojure method combinations should thrown an Exception if you try to combine aux methods with them."))
 
-(m/defmulti ^:private clojure-multifn class
+(m/defmulti ^:private clojure-multifn
+  class
   :combo (m/clojure-method-combination))
 
 (m/defmethod clojure-multifn Object
@@ -37,8 +38,8 @@
                                            Integer Number}]
     (t/testing (format "%s with default? %s" (pr-str klass) default?)
       (t/is (= (when expected-dispatch-value
-                 {:dispatch-value expected-dispatch-value})
-               (meta (m/effective-primary-method clojure-multifn klass))))
+                 expected-dispatch-value)
+               (:dispatch-value (meta (m/effective-primary-method clojure-multifn klass)))))
       (t/is (= (when expected-dispatch-value
-                 {:dispatch-value expected-dispatch-value})
-               (meta (m/effective-method clojure-multifn klass)))))))
+                 expected-dispatch-value)
+               (:dispatch-value (meta (m/effective-method clojure-multifn klass))))))))

--- a/test/methodical/impl/dispatcher/multi_default_test.clj
+++ b/test/methodical/impl/dispatcher/multi_default_test.clj
@@ -5,6 +5,8 @@
             methodical.interface)
   (:import methodical.interface.MethodTable))
 
+(set! *warn-on-reflection* true)
+
 (comment methodical.interface/keep-me)
 
 (t/deftest partially-specialized-default-dispatch-values-test

--- a/test/methodical/impl/dispatcher/standard_test.clj
+++ b/test/methodical/impl/dispatcher/standard_test.clj
@@ -4,6 +4,8 @@
             [methodical.interface :as i])
   (:import methodical.interface.MethodTable))
 
+(set! *warn-on-reflection* true)
+
 (t/deftest equality-test
   (t/is (= (impl/standard-dispatcher keyword)
            (impl/standard-dispatcher keyword))

--- a/test/methodical/macros_test.clj
+++ b/test/methodical/macros_test.clj
@@ -365,11 +365,3 @@
     #_{:clj-kondo/ignore [:unresolved-symbol]} #'docstring-multifn-primary-method-docstring
     (first (u/aux-methods docstring-multifn :around :docstring))
     #_{:clj-kondo/ignore [:unresolved-symbol]} #'docstring-multifn-around-method-docstring))
-
-
-;; NOCOMMIT
-(defmulti xyz (fn [x y] [x y]))
-
-(defmethod xyz '({:a 2} [2 3])
-  [x y]
-  {:x x, :y y})

--- a/test/methodical/macros_test.clj
+++ b/test/methodical/macros_test.clj
@@ -1,52 +1,253 @@
 (ns methodical.macros-test
-  (:require [clojure.test :as t]
-            [methodical.impl :as impl]
-            [methodical.interface :as i]
-            [methodical.macros :as m]
-            [methodical.util :as u]
-            [potemkin.namespaces :as p.namespaces]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :as t]
+   [methodical.impl :as impl]
+   [methodical.interface :as i]
+   [methodical.macros :as m]
+   [methodical.util :as u]
+   [potemkin.namespaces :as p.namespaces]))
 
-(t/deftest method-fn-name-test
-  (letfn [(method-fn-name [dispatch-value]
-            (#'m/method-fn-name 'my-multimethod "primary" dispatch-value))]
+;;; so the tests that do macroexansion work correctly regardless of namespace
+(t/use-fixtures :each (fn [thunk]
+                        (binding [*ns* (the-ns 'methodical.macros-test)]
+                          (thunk))))
+
+(t/deftest parse-defmulti-args-test
+  (t/are [args parsed] (= (quote parsed)
+                          (s/conform :methodical.macros/defmulti-args (quote args)))
+    (clojure-multifn
+     class
+     :combo (m/clojure-method-combination))
+    {:name-symb   clojure-multifn
+     :dispatch-fn class
+     :options     [{:k :combo, :v (m/clojure-method-combination)}]})
+
+  (t/testing "Throw error on invalid args (#36)"
+    (t/is (thrown?
+           clojure.lang.Compiler$CompilerException
+           (macroexpand
+            '(m/defmulti multifn :default
+               [x y z]
+               :ok))))))
+
+(t/deftest method-fn-symbol-test
+  (letfn [(method-fn-symbol [dispatch-value]
+            (#'m/method-fn-symbol 'my-multimethod "primary" dispatch-value))]
     (t/testing "Keyword dispatch value"
       (t/is (= 'my-multimethod-primary-method-something
-               (method-fn-name :something))))
+               (method-fn-symbol :something))))
     (t/testing "Symbol dispatch value"
       (t/is (= 'my-multimethod-primary-method-String
-               (method-fn-name 'String)))
+               (method-fn-symbol 'String)))
       (t/testing "with namespace"
         (t/is (= 'my-multimethod-primary-method-somewhere-something-cool
-                 (method-fn-name 'somewhere/something.cool)))))
+                 (method-fn-symbol 'somewhere/something.cool)))))
     (t/testing "String dispatch value"
       (t/is (= 'my-multimethod-primary-method-Wow-OK
-               (method-fn-name "Wow OK"))))
+               (method-fn-symbol "Wow OK"))))
     (t/testing "Composite dispatch value"
       (t/is (= 'my-multimethod-primary-method-k1-String
-               (method-fn-name [:k1 'String]))))
+               (method-fn-symbol [:k1 'String]))))
     (t/testing "Arbitrary expression dispatch value"
       (t/is (= 'my-multimethod-primary-method-if-true-String-Integer
-               (method-fn-name '[(if true String Integer)]))))
+               (method-fn-symbol '[(if true String Integer)]))))
     (t/testing "Munged function name should include keyword namespaces"
       (t/is (= 'my-multimethod-primary-method-somewhere-something
-               (method-fn-name :somewhere/something))))
+               (method-fn-symbol :somewhere/something))))
     (t/testing "Munged function name should replace periods in keywords (#60)"
       (t/testing "Munged function name should include keyword namespaces"
         (t/is (= 'my-multimethod-primary-method-somewhere-else-something
-                 (method-fn-name :somewhere.else/something)))
+                 (method-fn-symbol :somewhere.else/something)))
         (t/is (= 'my-multimethod-primary-method-somewhere-something-else
-                 (method-fn-name :somewhere/something-else)))))
+                 (method-fn-symbol :somewhere/something-else)))))
     (t/testing "Illegal characters"
       (t/is (= 'my-multimethod-primary-method-can_SINGLEQUOTE_t-use-this
-               (method-fn-name "can't use this"))))))
+               (method-fn-symbol "can't use this"))))))
 
 (m/defmulti ^:private mf1 :type)
 
-(m/define-primary-method mf1 :x
+(t/deftest parse-defmethod-args-test
+  (t/are [args parsed] (= (quote parsed)
+                          (#'m/parse-defmethod-args mf1 (quote args)))
+    (:x [m] body1 body2)
+    {:method-type    :primary
+     :dispatch-value :x
+     :fn-tail        ([m] body1 body2)}
+
+    (:x "Docstring" [m] body1 body2)
+    {:method-type    :primary
+     :dispatch-value :x
+     :docstring      "Docstring"
+     :fn-tail        ([m] body1 body2)}
+
+    (:after :x [m] body1 body2)
+    {:method-type    :aux
+     :qualifier      :after
+     :dispatch-value :x
+     :fn-tail        ([m] body1 body2)}
+
+    (:after :x "Docstring" [m] body1 body2)
+    {:method-type    :aux
+     :qualifier      :after
+     :dispatch-value :x
+     :docstring      "Docstring"
+     :fn-tail        ([m] body1 body2)}
+
+    ("str-dv" [m] body1 body2)
+    {:method-type    :primary
+     :dispatch-value "str-dv"
+     :fn-tail        ([m] body1 body2)}
+
+    (:before "str-dv" [m] body1 body2)
+    {:method-type    :aux
+     :qualifier      :before
+     :dispatch-value "str-dv"
+     :fn-tail        ([m] body1 body2)}
+
+    (:x ([x] y z) ([x y] z))
+    {:method-type    :primary
+     :dispatch-value :x
+     :fn-tail        (([x] y z)
+                      ([x y] z))}
+
+    (:around :x :k [x] y z)
+    {:method-type    :aux
+     :qualifier      :around
+     :dispatch-value :x
+     :unique-key     :k
+     :fn-tail        ([x] y z)}
+
+    (:around :x :k "Docstring" [x] y z)
+    {:method-type    :aux
+     :qualifier      :around
+     :dispatch-value :x
+     :unique-key     :k
+     :docstring      "Docstring"
+     :fn-tail        ([x] y z)}
+
+    (:around "str-dv" :k [x] y z)
+    {:method-type    :aux
+     :qualifier      :around
+     :dispatch-value "str-dv"
+     :unique-key     :k
+     :fn-tail        ([x] y z)}
+
+    (:around "str-dv" :k "Docstring" [x] y z)
+    {:method-type    :aux
+     :qualifier      :around
+     :dispatch-value "str-dv"
+     :unique-key     :k
+     :docstring      "Docstring"
+     :fn-tail        ([x] y z)}
+
+    (:after
+     :default
+     ([m]
+      (assoc m :after? true))
+     ([x m]
+      (assoc m :after? x)))
+    {:method-type    :aux
+     :qualifier      :after
+     :dispatch-value :default
+     :fn-tail        [([m]
+                       (assoc m :after? true))
+                      ([x m]
+                       (assoc m :after? x))]}
+
+    ;; awful dispatch values
+    ([{:a 1} [2 3]] [x y] {:x x, :y y})
+    {:method-type    :primary
+     :dispatch-value [{:a 1} [2 3]]
+     :fn-tail        [[x y] {:x x, :y y}]}
+
+    ([{:a 1} [2 3]] ([x] {:x x, :y y}) ([x y] {:x x, :y y}))
+    {:method-type    :primary
+     :dispatch-value [{:a 1} [2 3]]
+     :fn-tail        [([x] {:x x, :y y})
+                      ([x y] {:x x, :y y})]}
+
+    (({:a 1} [2 3]) [x y] {:x x, :y y})
+    {:method-type    :primary
+     :dispatch-value ({:a 1} [2 3])
+     :fn-tail        [[x y] {:x x, :y y}]}
+
+    (({:a 1} [2 3]) ([x] {:x x, :y y}) ([x y] {:x x, :y y}))
+    {:method-type    :primary
+     :dispatch-value ({:a 1} [2 3])
+     :fn-tail        [([x] {:x x, :y y})
+                      ([x y] {:x x, :y y})]}
+
+    ;; despite looking a little ambiguous, this is actually invalid because neither `:before` nor `([x] x)` are allowed
+    ;; as dispatch values; see [[methodical.macros/default-dispatch-value-spec]] for reasons why.
+    [:before ([x] x) ([x y] x)]
+    "([x] x) - failed: dispatch-value-spec in: [1] at: [:args-for-method-type :aux :dispatch-value]\n"
+
+    ;; here's another ambiguous one. Is this an `:after` aux method with dispatch value `"str"`, or a primary
+    ;; method with dispatch value `:after` and a docstring?
+    ;;
+    ;; The answer is that this is an aux method. We are no longer allowing aux qualifier keywords like `:after` as
+    ;; dispatch values.
+    [:after "str" [_x]]
+    {:method-type    :aux
+     :qualifier      :after
+     :dispatch-value "str"
+     :fn-tail        [[_x]]}))
+
+(m/defmethod mf1 :x
   [m]
   (assoc m :method :x))
 
-(t/deftest macros-test
+(t/deftest validate-defmethod-args-test
+  (t/are [invalid-form] (thrown?
+                         clojure.lang.Compiler$CompilerException
+                         (macroexpand (quote invalid-form)))
+
+    ;; bad aux method
+    (m/defmethod mf1 :arounds :x
+      [m]
+      (assoc m :method :x))
+
+    ;; missing function tail
+    (m/defmethod mf1 :around :x)
+
+    ;; invalid function tail
+    (m/defmethod mf1 :around :x {} a b c)
+
+    ;; string unique key
+    (m/defmethod mf1 :around :x "unique-key" "docstr" [a] b c)))
+
+(s/def ::arg-validation-spec
+  (s/or :default (partial = :default)
+        :x-y     (s/spec (s/cat :x keyword?
+                                :y keyword?))))
+
+(m/defmulti validate-args-spec-mf
+  {:arglists '([x y]), :dispatch-value-spec ::arg-validation-spec}
+  (fn [x y]
+    [(keyword x) (keyword y)]))
+
+(t/deftest validate-defmethod-dispatch-value-test
+  (t/testing ":dispatch-value-spec metadata should be attached to var and to the multifn itself"
+    (t/are [x] (= ::arg-validation-spec
+                  (:dispatch-value-spec (meta x)))
+      validate-args-spec-mf
+      #'validate-args-spec-mf))
+  (t/testing "valid"
+    (t/are [form] (some? (macroexpand (quote form)))
+      (m/defmethod validate-args-spec-mf :default [x y])
+      (m/defmethod validate-args-spec-mf [:x :y] [x y])))
+
+  (t/testing "invalid"
+    (t/are [form] (thrown?
+                   clojure.lang.Compiler$CompilerException
+                   (macroexpand (quote form)))
+      (m/defmethod validate-args-spec-mf :x [x y])
+      (m/defmethod validate-args-spec-mf [:x 1] [x y])
+      (m/defmethod validate-args-spec-mf [:x] [x y])
+      (m/defmethod validate-args-spec-mf [:x :y :z] [x y]))))
+
+(t/deftest defmethod-primary-methods-test
   (t/is (= mf1 (let [impl    (impl/standard-multifn-impl
                               (impl/thread-last-method-combination)
                               (impl/multi-default-dispatcher :type)
@@ -59,22 +260,22 @@
       constructors.")
   (t/is (= (mf1 {:type :x})
            {:type :x, :method :x})
-        "We should be able to define new primary methods using `define-primary-method`"))
+        "We should be able to define new primary methods using `defmethod`"))
 
 (m/defmulti ^:private mf2 :type)
 
-(m/define-primary-method mf2 :x
+(m/defmethod mf2 :x
   [m]
   (assoc m :method :x))
 
-(m/define-aux-method  mf2 :before :default
+(m/defmethod mf2 :before :default
   [m]
   (assoc m :before? true))
 
-(t/deftest define-aux-method-test
+(t/deftest defmethod-aux-method-test
   (t/is (= (mf2 {:type :x})
            {:type :x, :before? true, :method :x})
-        "We should be able to define new aux methods using `define-aux-method`"))
+        "We should be able to define new aux methods using `defmethod`"))
 
 (m/defmulti ^:private mf3 :type)
 
@@ -146,3 +347,29 @@
   (t/testing "not specifying a dispatch fn works (should use identity)"
     (t/is (= 1 (no-dispatch-fn :first)))
     (t/is (= 2 (no-dispatch-fn :second)))))
+
+(m/defmulti docstring-multifn)
+
+(m/defmethod docstring-multifn :docstring
+  "Docstring"
+  [_x])
+
+(m/defmethod docstring-multifn :around :docstring
+  "Docstring"
+  [_x])
+
+(t/deftest docstring-test
+  (t/are [x] (= "Docstring"
+                (:doc (meta x)))
+    (u/primary-method docstring-multifn :docstring)
+    #_{:clj-kondo/ignore [:unresolved-symbol]} #'docstring-multifn-primary-method-docstring
+    (first (u/aux-methods docstring-multifn :around :docstring))
+    #_{:clj-kondo/ignore [:unresolved-symbol]} #'docstring-multifn-around-method-docstring))
+
+
+;; NOCOMMIT
+(defmulti xyz (fn [x y] [x y]))
+
+(defmethod xyz '({:a 2} [2 3])
+  [x y]
+  {:x x, :y y})


### PR DESCRIPTION
Resolves #36
Resolves #46
Resolves #109
Resolves #110
Resolves #113

I started by trying to add specs to `defmethod` and `defmulti` and realized leveraging those to parse args made way more sense than parsing things the hard way. While writing tests and improving the custom Kondo hook I realized we had a few ambiguous parses for `defmethod`. So this PR introduces the following new rules for dispatch values:

A dispatch value as parsed to `defmethod` (i.e., not-yet-evaluated) can be ANYTHING other than the following two
things:

1. an legal aux qualifier for the current method combination, e.g. `:after` or `:around`

   It makes the parse for

   ```clj
   (m/defmethod mf :after \"str\" [_])
   ```

   ambiguous -- Is this an `:after` aux method with dispatch value `\"str\"`, or a primary method with dispatch value
   `:after` and a docstring? Since there's no clear way to decide which is which, we're going to have to disallow this.
   It's probably a good thing anyway since you're absolutely going to confuse the hell out of people if you use something
   like `:before` or `:around` as a *dispatch value*.

2. A list that can be interpreted as part of a n-arity fn tail i.e. `([args ...] body ...)`

   I know, theoretically it should be possible to do something dumb like this:

   ```clj
   (doseq [i    [0 1]
           :let [toucan :toucan pigeon :pigeon]]
     (m/defmethod my-multimethod :before ([toucan pigeon] i)
       ([x]
        ...)))
   ```

    but we are just UNFORTUNATELY going to have to throw up our hands and say we don't support it. The reason is in
    the example above it's ambiguous whether this is a `:before` aux method with dispatch value `([toucan pigeon] i)`,
    or a primary method with dispatch value `:before`. It's just impossible to tell what you meant. If you really want
    to do something wacky like this, let-bind the dispatch value to a symbol or something.

Once I sorted that all out it was relatively straightforward to knock out a few other issues at the same time and add docstring support and custom dispatch value validation support.

TODO: Update documentation 