### PR TITLE
Ambiguous primary method errors include multimethod name

### DIFF
--- a/src/methodical/impl.clj
+++ b/src/methodical/impl.clj
@@ -167,7 +167,6 @@
    {:pre [(map? m)]}
    (method-table.clojure/->ClojureMethodTable m)))
 
-
 (defn standard-method-table
   "Create a new standard method table that supports both primary and auxiliary methods."
   (^MethodTable []

--- a/src/methodical/macros.clj
+++ b/src/methodical/macros.clj
@@ -292,7 +292,9 @@
    (let [s (cond-> (format "%s-%s-method-%s" (name multifn) (name qualifier) (dispatch-val-name dispatch-val))
              unique-key
              (str "-" unique-key))]
-     (vary-meta (symbol s) assoc :private true))))
+     (vary-meta (symbol s) assoc :private true, :multifn (when-let [ns-symb (some-> (:ns (meta multifn)) ns-name name)]
+                                                           (when-let [symb (some-> (:name (meta multifn)) name)]
+                                                             (list 'var (symbol ns-symb symb))))))))
 
 (defn- emit-primary-method
   "Impl for [[defmethod]] for primary methods."

--- a/test/methodical/clojure_test.clj
+++ b/test/methodical/clojure_test.clj
@@ -144,9 +144,10 @@
   (with-local-vars [hierarchy (make-ambiguous-hierarchy)]
     (let [multifn (ambiguous-hierarchy-multifn hierarchy)]
       (t/testing "Ambiguous invocation"
-        (t/is (thrown-with-msg? IllegalArgumentException
-                              #"Multiple methods match dispatch value: :child -> :parent-1 and :parent-2"
-                              (multifn :child))
+        (t/is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Multimethod: multiple methods match dispatch value: :child -> :parent-1 and :parent-2"
+               (multifn :child))
               "Should throw Exception if multiple methods match dispatch value"))
 
       (t/testing "Ambiguous ancestor values"

--- a/test/methodical/datafy_test.clj
+++ b/test/methodical/datafy_test.clj
@@ -51,7 +51,8 @@
                                       :file     "methodical/datafy_test.clj"
                                       :line     15
                                       :column   1
-                                      :arglists '([next-method x y])}}
+                                      :arglists '([next-method x y])
+                                      :multifn  #'methodical.datafy-test/mf}}
                            :aux     {:before {[:x :default] [{:ns                    'methodical.datafy-test
                                                               :name                  'methodical.datafy-test/mf-before-method-x-default
                                                               :doc                   "Another docstring."
@@ -59,6 +60,7 @@
                                                               :column                1
                                                               :line                  20
                                                               :arglists              '([_x y])
+                                                              :multifn               #'methodical.datafy-test/mf
                                                               :methodical/unique-key 'methodical.datafy-test}]}
                                      :around {[:x :y] [{:ns                    'methodical.datafy-test
                                                         :name                  'methodical.datafy-test/mf-around-method-x-y
@@ -66,6 +68,7 @@
                                                         :column                1
                                                         :line                  25
                                                         :arglists              '([next-method x y])
+                                                        :multifn               #'methodical.datafy-test/mf
                                                         :methodical/unique-key 'methodical.datafy-test}]}}}
             :cache        {:class methodical.impl.cache.watching.WatchingCache
                            :cache {:class methodical.impl.cache.simple.SimpleCache

--- a/test/methodical/macros_test.clj
+++ b/test/methodical/macros_test.clj
@@ -51,7 +51,11 @@
             (#'macros/method-fn-symbol 'my-multimethod "primary" dispatch-value))]
     (t/testing "Keyword dispatch value"
       (t/is (= 'my-multimethod-primary-method-something
-               (method-fn-symbol :something))))
+               (method-fn-symbol :something)))
+      (t/is (= {:private true, :multifn nil} ; `:multifn` is `nil` here because we can't calculate it since technically
+                                             ; `method-fn-symbol` is supposed to be called with the multimethod itself
+                                             ; rather than a symbol.
+               (meta (method-fn-symbol :something)))))
     (t/testing "Symbol dispatch value"
       (t/is (= 'my-multimethod-primary-method-String
                (method-fn-symbol 'String)))
@@ -521,3 +525,8 @@
         ;; missing arities and disallowed arities
         ([x y] :ok)
         "{:arities {:required #{1 [:>= 3]}, :disallowed #{2}}}"))))
+
+(t/deftest defmethod-methods-should-include-multifn-metadata
+  (t/testing "Methods defined by defmethod should include the multifn they were defined for so we can use this info later"
+    (t/is (= #'methodical.macros-test/mf1
+             (:multifn (meta #_{:clj-kondo/ignore [:unresolved-symbol]} #'mf1-primary-method-x))))))


### PR DESCRIPTION
Fixes #126

This also changes the error thrown on ambiguous methods from an `IllegalArgumentException` to a `clojure.lang.ExceptionInfo`, and the `ex-data` map now includes the namespace, file, and line where each of the conflicting methods is defined.