### PR TITLE
Fix warning in loop

### DIFF
--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -167,7 +167,7 @@
 
 (defoperator :+ [methods invoke]
   (loop [sum 0, [method & more] methods]
-    (let [sum (+ (invoke method) sum)]
+    (let [sum (long (+ (invoke method) sum))]
       (if (seq more)
         (recur sum more)
         sum))))


### PR DESCRIPTION
Remove this warning

```
operator.clj:172 recur arg for primitive local: sum is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: sum
```