### PR TITLE
Add example for `:after :default` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ the last argument of the next function:
 ;; -> [:default :object :string]
 ```
 
+An example usecase for `:after` is chess. When looking up legal moves, you
+implement how each piece can move, then in `:after :default` limit it to only
+spaces on the board.
+
 #### `:around` methods
 
 `:around` methods are called around all other methods and give you the power to choose how or when to invoke those

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -59,7 +59,7 @@
     dispatch value, existing implementations of `MethodTable` are currently only able to remove exact matches -- for
     functions, this usually means identical objects.
 
-    In the future, I hope to fix this by storing unique indentifiers in the metadata of methods in the map."))
+    In the future, I hope to fix this by storing unique identifiers in the metadata of methods in the map."))
 
 (defprotocol Dispatcher
   "A *dispatcher* decides which dispatch value should be used for a given set of arguments, which primary and

--- a/test/methodical/util_test.clj
+++ b/test/methodical/util_test.clj
@@ -374,12 +374,12 @@
     (u/add-aux-method-with-unique-key! #'unique-key-multifn :before ::key #(conj % :before) "Florida key")
     (t/is (= 1
              (count (u/aux-methods unique-key-multifn :before ::key)))
-          "should be able to desctructively add an aux method with a unique key")
+          "should be able to destructively add an aux method with a unique key")
 
     (u/remove-aux-method-with-unique-key! #'unique-key-multifn :before ::key "Florida key")
     (t/is (= 0
              (count (u/aux-methods unique-key-multifn :before ::key)))
-          "should be able to desctructively remove an aux method with a unique key")))
+          "should be able to destructively remove an aux method with a unique key")))
 
 (t/deftest remove-all-methods-test
   (let [f (-> (m/default-multifn class)


### PR DESCRIPTION
I updated the readme, and noticed some spelling mistakes while running the linter, so I fixed those too.


----

----

Thanks for contributing to Methodical. Before open a pull request, please take a moment to:

- [X] Ensure the PR follows the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide).
- [X] Tests and linters pass. You can run all of the tests and linters locally with

      ./scripts/lint-and-test.sh

    GitHub Actions will also run these same tests against your PR.
- [x] Make sure you've included new tests for any new features or bugfixes.
- [x] New features are documented, or documentation is updated appropriately for any changed features.
- [x] Carefully review your own changes and revert any superfluous ones. (A good example would be moving words in the
      Markdown documentation to different lines in a way that wouldn't change how the rendered page itself would
      appear. These sorts of changes make a PR bigger than it needs to be, and, thus, harder to review.)

      Of course, indentation and typo fixes are not covered by this rule and are always appreciated.
- [x] Include a detailed explanation of what changes you're making and why you've made them. This will help me
      understand what's going on while we review it.

Once you've done all that, open a PR! Thanks for your contribution!
