### PR TITLE
Fix some startup warnings about recur targets

### DIFF
--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -167,7 +167,7 @@
 
 (defoperator :+ [methods invoke]
   (loop [sum 0, [method & more] methods]
-    (let [sum (long (+ (invoke method) sum))]
+    (let [sum (long (+ (long (invoke method)) sum))]
       (if (seq more)
         (recur sum more)
         sum))))

--- a/src/methodical/impl/combo/operator.clj
+++ b/src/methodical/impl/combo/operator.clj
@@ -167,7 +167,7 @@
 
 (defoperator :+ [methods invoke]
   (loop [sum 0, [method & more] methods]
-    (let [sum (long (+ (long (invoke method)) sum))]
+    (let [sum (+ (long (invoke method)) sum)]
       (if (seq more)
         (recur sum more)
         sum))))


### PR DESCRIPTION
before:

```
❯ clj -M:"$ALIASES"
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.algo.generic.math-functions, being replaced by: #'clojure.algo.generic.math-functions/abs
operator.clj:172 recur arg for primitive local: sum is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: sum
2024-05-06 22:46:49,580 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
```

after:

```
❯ clj -M:"$ALIASES"
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.algo.generic.math-functions, being replaced by: #'clojure.algo.generic.math-functions/abs
2024-05-06 22:52:35,962 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
```
