### PR TITLE
Attempt at widening the arities for multimethod calls

### DIFF
--- a/src/methodical/impl/combo/clos.clj
+++ b/src/methodical/impl/combo/clos.clj
@@ -22,34 +22,49 @@
     combined-method
     (fn
       ([]
-       (doseq [f befores]
-         (f))
+       (doseq [before befores]
+         (before))
        (combined-method))
 
       ([a]
-       (doseq [f befores]
-         (f a))
+       (doseq [before befores]
+         (before a))
        (combined-method a))
 
       ([a b]
-       (doseq [f befores]
-         (f a b))
+       (doseq [before befores]
+         (before a b))
        (combined-method a b))
 
       ([a b c]
-       (doseq [f befores]
-         (f a b c))
+       (doseq [before befores]
+         (before a b c))
        (combined-method a b c))
 
       ([a b c d]
-       (doseq [f befores]
-         (f a b c d))
+       (doseq [before befores]
+         (before a b c d))
        (combined-method a b c d))
 
-      ([a b c d & more]
-       (doseq [f befores]
-         (apply f a b c d more))
-       (apply combined-method a b c d more)))))
+      ([a b c d e]
+       (doseq [before befores]
+         (before a b c d e))
+       (combined-method a b c d e))
+
+      ([a b c d e f]
+       (doseq [before befores]
+         (before a b c d e f))
+       (combined-method a b c d e f))
+
+      ([a b c d e f g]
+       (doseq [before befores]
+         (before a b c d e f g))
+       (combined-method a b c d e f g))
+
+      ([a b c d e f g & more]
+       (doseq [before befores]
+         (apply before a b c d e f g more))
+       (apply combined-method a b c d e f g more)))))
 
 (defn- apply-afters [combined-method afters]
   (if (empty? afters)

--- a/src/methodical/impl/combo/common.clj
+++ b/src/methodical/impl/combo/common.clj
@@ -1,6 +1,91 @@
 (ns methodical.impl.combo.common
   "Utility functions for implementing method combinations.")
 
+(defn partial*
+  "[[clojure.core/partial]] but with more direct arities."
+  ([inner] inner)
+  ([inner a]
+   (fn
+     ([]                          (inner a))
+     ([p]                         (inner a p))
+     ([p q]                       (inner a p q))
+     ([p q r]                     (inner a p q r))
+     ([p q r s]                   (inner a p q r s))
+     ([p q r s t]                 (inner a p q r s t))
+     ([p q r s t u]               (inner a p q r s t u))
+     ([p q r s t u v]             (inner a p q r s t u v))
+     ([p q r s t u v x]           (inner a p q r s t u v x))
+     ([p q r s t u v x y]         (inner a p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a p q r s t u v x y z))))
+  ([inner a b]
+   (fn
+     ([]                          (inner a b))
+     ([p]                         (inner a b p))
+     ([p q]                       (inner a b p q))
+     ([p q r]                     (inner a b p q r))
+     ([p q r s]                   (inner a b p q r s))
+     ([p q r s t]                 (inner a b p q r s t))
+     ([p q r s t u]               (inner a b p q r s t u))
+     ([p q r s t u v]             (inner a b p q r s t u v))
+     ([p q r s t u v x]           (inner a b p q r s t u v x))
+     ([p q r s t u v x y]         (inner a b p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a b p q r s t u v x y z))))
+  ([inner a b c]
+   (fn
+     ([]                          (inner a b c))
+     ([p]                         (inner a b c p))
+     ([p q]                       (inner a b c p q))
+     ([p q r]                     (inner a b c p q r))
+     ([p q r s]                   (inner a b c p q r s))
+     ([p q r s t]                 (inner a b c p q r s t))
+     ([p q r s t u]               (inner a b c p q r s t u))
+     ([p q r s t u v]             (inner a b c p q r s t u v))
+     ([p q r s t u v x]           (inner a b c p q r s t u v x))
+     ([p q r s t u v x y]         (inner a b c p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a b c p q r s t u v x y z))))
+  ([inner a b c d]
+   (fn
+     ([]                          (inner a b c d))
+     ([p]                         (inner a b c d p))
+     ([p q]                       (inner a b c d p q))
+     ([p q r]                     (inner a b c d p q r))
+     ([p q r s]                   (inner a b c d p q r s))
+     ([p q r s t]                 (inner a b c d p q r s t))
+     ([p q r s t u]               (inner a b c d p q r s t u))
+     ([p q r s t u v]             (inner a b c d p q r s t u v))
+     ([p q r s t u v x]           (inner a b c d p q r s t u v x))
+     ([p q r s t u v x y]         (inner a b c d p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a b c d p q r s t u v x y z))))
+  ([inner a b c d e]
+   (fn
+     ([]                          (inner a b c d e))
+     ([p]                         (inner a b c d e p))
+     ([p q]                       (inner a b c d e p q))
+     ([p q r]                     (inner a b c d e p q r))
+     ([p q r s]                   (inner a b c d e p q r s))
+     ([p q r s t]                 (inner a b c d e p q r s t))
+     ([p q r s t u]               (inner a b c d e p q r s t u))
+     ([p q r s t u v]             (inner a b c d e p q r s t u v))
+     ([p q r s t u v x]           (inner a b c d e p q r s t u v x))
+     ([p q r s t u v x y]         (inner a b c d e p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a e b c d p q r s t u v x y z))))
+  ([inner a b c d e f]
+   (fn
+     ([]                          (inner a b c d e f))
+     ([p]                         (inner a b c d e f p))
+     ([p q]                       (inner a b c d e f p q))
+     ([p q r]                     (inner a b c d e f p q r))
+     ([p q r s]                   (inner a b c d e f p q r s))
+     ([p q r s t]                 (inner a b c d e f p q r s t))
+     ([p q r s t u]               (inner a b c d e f p q r s t u))
+     ([p q r s t u v]             (inner a b c d e f p q r s t u v))
+     ([p q r s t u v x]           (inner a b c d e f p q r s t u v x))
+     ([p q r s t u v x y]         (inner a b c d e f p q r s t u v x y))
+     ([p q r s t u v x y & z]     (apply inner a e f b c d p q r s t u v x y z))))
+  ([inner a b c d e f & more]
+   (fn [& args]
+     (inner a b c d e f (concat more args)))))
+
 (defn combine-primary-methods
   "Combine all `primary-methods` into a single combined method. Each method is partially bound with a `next-method`
   arg."
@@ -8,7 +93,7 @@
   (when (seq primary-methods)
     (reduce
      (fn [next-method primary-method]
-       (with-meta (partial primary-method next-method) (meta primary-method)))
+       (with-meta (partial* primary-method next-method) (meta primary-method)))
      nil
      (reverse primary-methods))))
 
@@ -19,7 +104,7 @@
   [combined-method around-methods]
   (reduce
    (fn [combined-method around-method]
-     (with-meta (partial around-method combined-method) (meta around-method)))
+     (with-meta (partial* around-method combined-method) (meta around-method)))
    combined-method
    around-methods))
 
@@ -36,7 +121,7 @@
     (apply f fn-tail)
 
     (vector? (ffirst fn-tail))
-    (map (partial transform-fn-tail f) fn-tail)
+    (map (partial* transform-fn-tail f) fn-tail)
 
     :else
     (throw (ex-info (format "Invalid fn tail: %s. Expected ([arg*] & body) or (([arg*] & body)+)"

--- a/src/methodical/impl/combo/threaded.clj
+++ b/src/methodical/impl/combo/threaded.clj
@@ -38,12 +38,15 @@
            optimized-one-arg-fn (apply comp (reverse methods))]
        (combo.common/apply-around-methods
         (-> (fn
-              ([]               (optimized-one-arg-fn))
-              ([a]              (optimized-one-arg-fn a))
-              ([a b]            (threaded-fn a b))
-              ([a b c]          (threaded-fn a b c))
-              ([a b c d]        (threaded-fn a b c d))
-              ([a b c d & more] (apply threaded-fn a b c d more)))
+              ([]                     (optimized-one-arg-fn))
+              ([a]                    (optimized-one-arg-fn a))
+              ([a b]                  (threaded-fn a b))
+              ([a b c]                (threaded-fn a b c))
+              ([a b c d]              (threaded-fn a b c d))
+              ([a b c d e]            (threaded-fn a b c d e))
+              ([a b c d e f]          (threaded-fn a b c d e f))
+              ([a b c d e f g]        (threaded-fn a b c d e f g))
+              ([a b c d e f g & more] (apply threaded-fn a b c d e f g more)))
             (vary-meta assoc :methodical/combined-method? true))
         around)))))
 
@@ -59,21 +62,27 @@
 (defmethod threading-invoker :thread-first
   [_]
   (fn
-    ([a b]            [a (fn [method a*] (method a* b))])
-    ([a b c]          [a (fn [method a*] (method a* b c))])
-    ([a b c d]        [a (fn [method a*] (method a* b c d))])
-    ([a b c d & more] [a (fn [method a*] (apply method a* b c d more))])))
+    ([a b]                  [a (fn [method a*] (method a* b))])
+    ([a b c]                [a (fn [method a*] (method a* b c))])
+    ([a b c d]              [a (fn [method a*] (method a* b c d))])
+    ([a b c d e]            [a (fn [method a*] (method a* b c d e))])
+    ([a b c d e f]          [a (fn [method a*] (method a* b c d e f))])
+    ([a b c d e f g]        [a (fn [method a*] (method a* b c d e f g))])
+    ([a b c d e f g & more] [a (fn [method a*] (apply method a* b c d e f g more))])))
 
 (defmethod threading-invoker :thread-last
   [_]
   (fn
-    ([a b]     [b (fn [method b*] (method a b*))])
-    ([a b c]   [c (fn [method c*] (method a b c*))])
-    ([a b c d] [d (fn [method d*] (method a b c d*))])
+    ([a b]           [b (fn [method b*] (method a b*))])
+    ([a b c]         [c (fn [method c*] (method a b c*))])
+    ([a b c d]       [d (fn [method d*] (method a b c d*))])
+    ([a b c d e]     [e (fn [method e*] (method a b c d e*))])
+    ([a b c d e f]   [f (fn [method f*] (method a b c d e f*))])
+    ([a b c d e f g] [g (fn [method g*] (method a b c d e f g*))])
 
-    ([a b c d & more]
+    ([a b c d e f g & more]
      (let [last-val (last more)
-           butlast* (vec (concat [a b c d] (butlast more)))]
+           butlast* (vec (concat [a b c d e f g] (butlast more)))]
        [last-val
         (fn [method last*]
           (apply method (conj butlast* last*)))]))))

--- a/src/methodical/impl/dispatcher/everything.clj
+++ b/src/methodical/impl/dispatcher/everything.clj
@@ -32,12 +32,15 @@
         (= prefs (.prefs another))))))
 
   Dispatcher
-  (dispatch-value [_]                   nil)
-  (dispatch-value [_ _a]                nil)
-  (dispatch-value [_ _a _b]             nil)
-  (dispatch-value [_ _a _b _c]          nil)
-  (dispatch-value [_ _a _b _c _d]       nil)
-  (dispatch-value [_ _a _b _c _d _more] nil)
+  (dispatch-value [_]                            nil)
+  (dispatch-value [_ _a]                         nil)
+  (dispatch-value [_ _a _b]                      nil)
+  (dispatch-value [_ _a _b _c]                   nil)
+  (dispatch-value [_ _a _b _c _d]                nil)
+  (dispatch-value [_ _a _b _c _d _e]             nil)
+  (dispatch-value [_ _a _b _c _d _e _f]          nil)
+  (dispatch-value [_ _a _b _c _d _e _f _g]       nil)
+  (dispatch-value [_ _a _b _c _d _e _f _g _more] nil)
 
   (matching-primary-methods [_ method-table _]
     (let [primary-methods (i/primary-methods method-table)

--- a/src/methodical/impl/dispatcher/multi_default.clj
+++ b/src/methodical/impl/dispatcher/multi_default.clj
@@ -155,12 +155,15 @@
         (= prefs         (.prefs another))))))
 
   Dispatcher
-  (dispatch-value [_]              (dispatch-fn))
-  (dispatch-value [_ a]            (dispatch-fn a))
-  (dispatch-value [_ a b]          (dispatch-fn a b))
-  (dispatch-value [_ a b c]        (dispatch-fn a b c))
-  (dispatch-value [_ a b c d]      (dispatch-fn a b c d))
-  (dispatch-value [_ a b c d more] (apply dispatch-fn a b c d more))
+  (dispatch-value [_]                    (dispatch-fn))
+  (dispatch-value [_ a]                  (dispatch-fn a))
+  (dispatch-value [_ a b]                (dispatch-fn a b))
+  (dispatch-value [_ a b c]              (dispatch-fn a b c))
+  (dispatch-value [_ a b c d]            (dispatch-fn a b c d))
+  (dispatch-value [_ a b c d e]          (dispatch-fn a b c d e))
+  (dispatch-value [_ a b c d e f]        (dispatch-fn a b c d e f))
+  (dispatch-value [_ a b c d e f g]      (dispatch-fn a b c d e f g))
+  (dispatch-value [_ a b c d e f g more] (apply dispatch-fn a b c d e f g more))
 
   (matching-primary-methods [_ method-table dispatch-value]
     (matching-primary-methods

--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -131,12 +131,15 @@
         (= prefs         (.prefs another))))))
 
   Dispatcher
-  (dispatch-value [_]              (dispatch-fn))
-  (dispatch-value [_ a]            (dispatch-fn a))
-  (dispatch-value [_ a b]          (dispatch-fn a b))
-  (dispatch-value [_ a b c]        (dispatch-fn a b c))
-  (dispatch-value [_ a b c d]      (dispatch-fn a b c d))
-  (dispatch-value [_ a b c d more] (apply dispatch-fn a b c d more))
+  (dispatch-value [_]                    (dispatch-fn))
+  (dispatch-value [_ a]                  (dispatch-fn a))
+  (dispatch-value [_ a b]                (dispatch-fn a b))
+  (dispatch-value [_ a b c]              (dispatch-fn a b c))
+  (dispatch-value [_ a b c d]            (dispatch-fn a b c d))
+  (dispatch-value [_ a b c d e]          (dispatch-fn a b c d e))
+  (dispatch-value [_ a b c d e f]        (dispatch-fn a b c d e f))
+  (dispatch-value [_ a b c d e f g]      (dispatch-fn a b c d e f g))
+  (dispatch-value [_ a b c d e f g more] (apply dispatch-fn a b c d e f g more))
 
   (matching-primary-methods [_ method-table dispatch-value]
     (matching-primary-methods

--- a/src/methodical/impl/standard.clj
+++ b/src/methodical/impl/standard.clj
@@ -60,9 +60,20 @@
   ([^MultiFnImpl impl mta a b c d]
    (invoke-multi impl mta a b c d))
 
-  ([^MultiFnImpl impl mta a b c d & more]
+  ([^MultiFnImpl impl mta a b c d e]
+   #_(println "invoke-multifn 5-arity")
+   (invoke-multi impl mta a b c d e))
+
+  ([^MultiFnImpl impl mta a b c d e f]
+   (invoke-multi impl mta a b c d e f))
+
+  ([^MultiFnImpl impl mta a b c d e f g]
+   (invoke-multi impl mta a b c d e f g))
+
+  ([^MultiFnImpl impl mta a b c d e f g & more]
    ;; TODO: possible to use the macro somehow in this case?
-   (try (apply (effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d more)) a b c d more)
+   (try (apply (effective-method impl (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d e f g more))
+               a b c d e f g more)
         (catch Exception e
           (handle-effective-method-exception e mta)))))
 
@@ -109,8 +120,14 @@
     (.dispatch-value ^Dispatcher (.dispatcher impl) a b c))
   (dispatch-value [_ a b c d]
     (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d))
-  (dispatch-value [_ a b c d more]
-    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d more))
+  (dispatch-value [_ a b c d e]
+    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d e))
+  (dispatch-value [_ a b c d e f]
+    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d e f))
+  (dispatch-value [_ a b c d e f g]
+    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d e f g))
+  (dispatch-value [_ a b c d e f g more]
+    (.dispatch-value ^Dispatcher (.dispatcher impl) a b c d e f g more))
 
   (matching-primary-methods [_ method-table dispatch-value]
     (i/matching-primary-methods (.dispatcher impl) method-table dispatch-value))

--- a/src/methodical/interface.clj
+++ b/src/methodical/interface.clj
@@ -72,7 +72,10 @@
     [dispatcher a b]
     [dispatcher a b c]
     [dispatcher a b c d]
-    [dispatcher a b c d more]
+    [dispatcher a b c d e]
+    [dispatcher a b c d e f]
+    [dispatcher a b c d e f g]
+    [dispatcher a b c d e f g more]
     "Return an appropriate dispatch value for args passed to a multimethod. (This method is equivalent in purpose to
     the dispatch function of vanilla Clojure multimethods.)")
 


### PR DESCRIPTION
There's a lot of `apply`/`RestFn`/`invoke` etc. dynamic call machinery in Methodical's stack traces. This is an attempt to remove some of it by going up to 7 direct args for multimethod calls. (And dispatch functions.)

This hasn't removed much of the `apply` overhead in practice because `with-meta` on a function wraps it with a naive function subclass that always does a dynamic call. There are probably still some places that more dynamic calls are creeping in, but I ran out of time to dig deeper.

This may not go anywhere until I get back, but I wanted to publish this just in case.

Thanks for contributing to Methodical. Before open a pull request, please take a moment to:

- [ ] Ensure the PR follows the [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide).
- [ ] Tests and linters pass. You can run all of the tests and linters locally with

      ./scripts/lint-and-test.sh

    GitHub Actions will also run these same tests against your PR.
- [ ] Make sure you've included new tests for any new features or bugfixes.
- [ ] New features are documented, or documentation is updated appropriately for any changed features.
- [ ] Carefully review your own changes and revert any superfluous ones. (A good example would be moving words in the
      Markdown documentation to different lines in a way that wouldn't change how the rendered page itself would
      appear. These sorts of changes make a PR bigger than it needs to be, and, thus, harder to review.)

      Of course, indentation and typo fixes are not covered by this rule and are always appreciated.
- [ ] Include a detailed explanation of what changes you're making and why you've made them. This will help me
      understand what's going on while we review it.

Once you've done all that, open a PR! Thanks for your contribution!
