### PR TITLE
[dispatcher] Use more efficient iteration in matching-primary-pairs

### DIFF
--- a/src/methodical/impl/dispatcher/standard.clj
+++ b/src/methodical/impl/dispatcher/standard.clj
@@ -19,9 +19,10 @@
   method (if any); pairs are sorted in order from most-specific to least-specific."
   [{:keys [hierarchy prefs method-map dispatch-value]}]
   {:pre [(map? method-map)]}
-  (let [matches        (for [[a-dispatch-val method] method-map
-                             :when                   (isa? hierarchy dispatch-value a-dispatch-val)]
-                         [a-dispatch-val method])]
+  (let [matches (reduce-kv (fn [acc a-dispatch-val method]
+                             (cond-> acc
+                               (isa? hierarchy dispatch-value a-dispatch-val) (conj [a-dispatch-val method])))
+                           [] method-map)]
     (when (seq matches)
       (sort-by first (dispatcher.common/domination-comparator hierarchy prefs dispatch-value) matches))))
 


### PR DESCRIPTION
Same reasoning as #152 – non-cached dispatcher still matters; and a reduce-kv is more optimized for iterating maps than a generic `for`. I'm deliberately not using transients to accumulate because I assume that absolute most matching method lists will be tiny (a few elements), and the overhead of transients outweighs regular vectors on such small inputs.